### PR TITLE
fix(HTTP): add Clear() function

### DIFF
--- a/docs/webserv.pu
+++ b/docs/webserv.pu
@@ -66,6 +66,7 @@ class HttpMessage {
   + GetHeader(const string&) const : const string&
   + GetBody() const : const string&
   + Now(time_t) : string
+  + Clear(): void
   - {abstract} ParseMessage() : void
   - {abstract} ParseStartline() : void
   - {abstract} ParseHeader() : void
@@ -78,6 +79,7 @@ class Request {
   + GetMethod() const : enum Method
   + GetURI() const : const string&
   + GetStatus() const : enum ParseStatus
+  + Clear() : void
   - {abstract} ParseMessage() : void
   - {abstract} ParseStartline() : void
   - {abstract} ParseHeader() : void
@@ -92,6 +94,7 @@ class Response {
   + GetStatusCode() const : int
   + GetStautsMessage() const : const string&
   + Str() : string
+  + Clear() : void
   - SetStatusMessage(const string&) : void
   - {abstract} ParseMessage() : void
   - {abstract} ParseStartline() : void

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -92,10 +92,7 @@ void Client::Prepare(void) {
       read_fd_ = open("./docs/html/index.html", O_RDONLY);
       fcntl(read_fd_, F_SETFL, O_NONBLOCK);
 
-      response_.SetStatusCode(200);
       response_.AppendHeader("Content-Type", "text/html");
-      response_.AppendHeader("Server", "Webserv");
-      response_.AppendHeader("Date", "Wed, 30 Jun 2021 08:25:23 GMT");
       break;
 
     case WRITE_FILE:
@@ -104,8 +101,6 @@ void Client::Prepare(void) {
 
       response_.SetStatusCode(201);
       response_.AppendHeader("Content-Type", "text/html");
-      response_.AppendHeader("Server", "Webserv");
-      response_.AppendHeader("Date", "Wed, 30 Jun 2021 08:25:23 GMT");
       response_.AppendHeader("Content-Location", "/post.html");
       break;
 
@@ -114,16 +109,12 @@ void Client::Prepare(void) {
 
       response_.SetStatusCode(200);
       response_.AppendHeader("Content-Type", "text/html");
-      response_.AppendHeader("Server", "Webserv");
-      response_.AppendHeader("Date", "Wed, 30 Jun 2021 08:25:23 GMT");
       break;
 
     case WRITE_CLIENT:
       if (is_autoindex) {
         response_.SetStatusCode(200);
         response_.AppendHeader("Content-Type", "text/html");
-        response_.AppendHeader("Server", "Webserv");
-        response_.AppendHeader("Date", "Wed, 30 Jun 2021 08:25:23 GMT");
 
         std::string tmp = MakeAutoIndexContent("./docs");
 
@@ -163,7 +154,8 @@ int Client::send(int client_fd) {
   if (ret > 0) {
     std::cout << "send to   " + host_ip_ << ":" << port_ << std::endl;
   }
-
+  response_.Clear();
+  request_.Clear();
   return ret;
 }
 

--- a/srcs/HttpMessage.cpp
+++ b/srcs/HttpMessage.cpp
@@ -60,6 +60,14 @@ std::string HttpMessage::Now(time_t time) const {
   return std::string(buf);
 }
 
+void HttpMessage::Clear() {
+  status_ = STARTLINE;
+  http_version_ = "1.1";
+  headers_.clear();
+  body_.clear();
+  raw_.clear();
+}
+
 void HttpMessage::ParseMessage() {
   try {
     ParseStartline();

--- a/srcs/HttpMessage.hpp
+++ b/srcs/HttpMessage.hpp
@@ -55,6 +55,7 @@ class HttpMessage {
   const std::string& GetBody() const;
 
   std::string Now(time_t time = std::time(NULL)) const;
+  void Clear();
 
   // Parse exception
   class ParseBodyException : public std::runtime_error {

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -21,6 +21,12 @@ const std::string& Request::GetURI() const {
 
 enum Request::ParseStatus Request::GetStatus() const { return status_; }
 
+void Request::Clear() {
+  HttpMessage::Clear();
+  method_ = INVALID;
+  uri_.clear();
+}
+
 void Request::ParseStartline() {
   if (raw_.find("\r\n") == std::string::npos)
     throw ParseStartlineException("Incomplete startline");

--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -19,6 +19,8 @@ class Request : public HttpMessage {
   const std::string& GetURI() const;
   enum ParseStatus GetStatus() const;
 
+  void Clear();
+
   // Fatal exception
   class RequestFatalException : public std::runtime_error {
    public:

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -97,6 +97,15 @@ std::string Response::Str() const {
   return s.str();
 }
 
+void Response::Clear() {
+  HttpMessage::Clear();
+  http_version_ = "1.1";
+  SetStatusCode(200);
+  AppendHeader("Content-Type", "");
+  AppendHeader("Date", Now());
+  AppendHeader("Server", "webserv");
+}
+
 void Response::SetStatusMessage(const std::string& msg) {
   status_message_ = msg;
 }

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -31,6 +31,7 @@ class Response : public HttpMessage {
   const std::string& GetStatusMessage() const;
 
   std::string Str() const;
+  void Clear();
 
   class StatusException : public std::domain_error {
    public:


### PR DESCRIPTION
## 概要
HttpMessage, Request, ResponseクラスにClear()を追加しました。
レスポンスをクライアントに送った後に呼び出すようにしています。
また、ヘッダーのうちDateとServerはResponseのコンストラクタ で設定するようにしました。

## 関連issue
#17 