### PR TITLE
CGI parser

### DIFF
--- a/docs/chunked.cgi
+++ b/docs/chunked.cgi
@@ -13,11 +13,9 @@ sub html {
     $str =~ s/"/&quot;/g;
     $str =~ s/'/&#x27;/g;
     return $str;
-}    
+}
 
 #
 # ヘッダ部を書き出します
 #
-print <<EOF;
-Content-Type: text/html\nTransfer-Encoding: chunked\n\nB\r\nmcgee mine\n\r\n0\r\n\r\n
-EOF
+print "Content-Type: text/html\nTransfer-Encoding: chunked\n\nB\r\nmcgee mine\n\r\n0\r\n\r\n"

--- a/docs/webserv.pu
+++ b/docs/webserv.pu
@@ -51,6 +51,7 @@ class Client {
 
 class HttpMessage {
   - status : enum ParseStatus
+  - delim : string
   - raw : string
   - http_version : string
   - headers : map<string, string>
@@ -93,6 +94,7 @@ class Response {
   + SetStatusCode(int) : void
   + GetStatusCode() const : int
   + GetStautsMessage() const : const string&
+  + EndCGI() : void
   + Str() : string
   + Clear() : void
   - SetStatusMessage(const string&) : void

--- a/srcs/CGI.cpp
+++ b/srcs/CGI.cpp
@@ -5,7 +5,7 @@
 const int CGI::num_envs_ = 18;
 
 CGI::CGI(const Request &request) {
-  args_ = ft::split("./docs/chunked.cgi+mcgee+mine", '+');
+  args_ = ft::split("./docs/perl.cgi+mcgee+mine", '+');
 
   envs_map_["AUTH_TYPE"] = "";
   envs_map_["CONTENT_LENGTH"] = "";

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -170,7 +170,7 @@ void Client::ExecCGI(int *pipe_write, int *pipe_read, char **args,
   close(pipe_read[0]);
   close(pipe_read[1]);
 
-  execve("./docs/chunked.cgi", args, envs);
+  execve("./docs/perl.cgi", args, envs);
   exit(EXIT_FAILURE);
 }
 

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -37,13 +37,20 @@ class Client : public Socket {
   std::string GetHostIp() { return host_ip_; };
 
   void AppendResponseBody(std::string buf) { response_.AppendBody(buf); };
-  void AppendResponseHeader(std::string key, std::string val) {response_.AppendHeader(key, val); };
-  void AppendResponseHeader(std::pair<std::string, std::string> header) {response_.AppendHeader(header); };
+  void AppendResponseHeader(std::string key, std::string val) {
+    response_.AppendHeader(key, val);
+  };
+  void AppendResponseHeader(std::pair<std::string, std::string> header) {
+    response_.AppendHeader(header);
+  };
+  void AppendResponseRawData(std::string data, bool is_continue) {
+    response_.AppendRawData(data);
+    if (!is_continue) response_.EndCGI();
+  };
 
   void SetResponseBody(std::string buf) { response_.SetBody(buf); };
 
   void SetStatus(enum SocketStatus status);
-
 
   std::string MakeAutoIndexContent(std::string dir_path);
 
@@ -58,4 +65,4 @@ class Client : public Socket {
   int read_fd_;
 };
 
-#endif
+#endif /* CLIENT_HPP */

--- a/srcs/HttpMessage.cpp
+++ b/srcs/HttpMessage.cpp
@@ -97,7 +97,7 @@ void HttpMessage::ParseHeader() {
       std::pair<std::string, std::string> header = ft::div(all[i], ':');
       AppendHeader(header);
     }
-    raw_ = raw_.substr(raw_.find(delim_ + delim_) + 4);
+    raw_ = raw_.substr(raw_.find(delim_ + delim_) + delim_.size() * 2);
     status_ = BODY;
   }
 }

--- a/srcs/HttpMessage.cpp
+++ b/srcs/HttpMessage.cpp
@@ -2,7 +2,7 @@
 
 #include "utility.hpp"
 
-HttpMessage::HttpMessage() : status_(STARTLINE) {}
+HttpMessage::HttpMessage() : status_(STARTLINE), delim_("\r\n") {}
 
 HttpMessage::~HttpMessage() {}
 
@@ -84,18 +84,20 @@ void HttpMessage::ParseMessage() {
 
 void HttpMessage::ParseHeader() {
   if (status_ == HEADER) {
-    if (raw_.find("\r\n\r\n") == std::string::npos)
+    if (raw_.find(delim_ + delim_) == std::string::npos)
       throw ParseHeaderException("Incomplete header");
-    std::string flat = raw_.substr(0, raw_.find("\r\n\r\n"));
-    std::vector<std::string> all = ft::vsplit(flat, '\r');
-    for (std::string::size_type i = 0; i < all.size(); i++) {
-      all[i] = ft::trim(all[i], "\n");
+    std::string flat = raw_.substr(0, raw_.find(delim_ + delim_));
+    std::vector<std::string> all = ft::vsplit(flat, '\n');
+    if (delim_ == "\r\n") {
+      for (std::string::size_type i = 0; i < all.size(); i++) {
+        all[i] = ft::trim(all[i], "\r");
+      }
     }
     for (std::string::size_type i = 0; i < all.size(); i++) {
       std::pair<std::string, std::string> header = ft::div(all[i], ':');
       AppendHeader(header);
     }
-    raw_ = raw_.substr(raw_.find("\r\n\r\n") + 4);
+    raw_ = raw_.substr(raw_.find(delim_ + delim_) + 4);
     status_ = BODY;
   }
 }

--- a/srcs/HttpMessage.hpp
+++ b/srcs/HttpMessage.hpp
@@ -22,9 +22,8 @@ class HttpMessage {
   typedef std::map<std::string, std::string> http_header;
 
   enum ParseStatus status_;
-
+  std::string delm_;
   std::string raw_;
-
   std::string http_version_;
   http_header headers_;
   std::string body_;

--- a/srcs/HttpMessage.hpp
+++ b/srcs/HttpMessage.hpp
@@ -22,7 +22,7 @@ class HttpMessage {
   typedef std::map<std::string, std::string> http_header;
 
   enum ParseStatus status_;
-  std::string delm_;
+  std::string delim_;
   std::string raw_;
   std::string http_version_;
   http_header headers_;

--- a/srcs/HttpMessage.hpp
+++ b/srcs/HttpMessage.hpp
@@ -1,5 +1,5 @@
-#ifndef HTTPMESSAGE_H
-#define HTTPMESSAGE_H
+#ifndef HTTPMESSAGE_HPP
+#define HTTPMESSAGE_HPP
 
 #include <ctime>
 #include <map>
@@ -77,4 +77,4 @@ class HttpMessage {
   };
 };
 
-#endif /* HTTPMESSAGE_H */
+#endif /* HTTPMESSAGE_HPP */

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -79,6 +79,8 @@ void Response::SetBody(std::string body) { body_ = body; }
 
 int Response::GetStatusCode() const { return status_code_; }
 
+void Response::EndCGI() { status_ = DONE; }
+
 const std::string& Response::GetStatusMessage() const {
   return status_message_;
 }
@@ -110,15 +112,17 @@ void Response::SetStatusMessage(const std::string& msg) {
   status_message_ = msg;
 }
 
+void Response::ParseMessage() {
+  delim_ = "\n";
+  HttpMessage::ParseMessage();
+}
+
 void Response::ParseStartline() { HttpMessage::ParseStartline(); }
 
 void Response::ParseHeader() { HttpMessage::ParseHeader(); }
 
-void Response::ParseMessage() { HttpMessage::ParseMessage(); }
-
 void Response::ParseBody() {
   if (status_ == BODY) {
     AppendBody(raw_);
-    status_ = DONE;
   }
 }

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -124,5 +124,6 @@ void Response::ParseHeader() { HttpMessage::ParseHeader(); }
 void Response::ParseBody() {
   if (status_ == BODY) {
     AppendBody(raw_);
+    raw_ = "";
   }
 }

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -30,6 +30,7 @@ class Response : public HttpMessage {
   int GetStatusCode() const;
   const std::string& GetStatusMessage() const;
 
+  void EndCGI();
   std::string Str() const;
   void Clear();
 

--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -36,7 +36,6 @@ class WebServ {
   int ExecClientEvent(socket_iter it);
 
   void ParseConig(const std::string& path);
-  void ParseCGIOutput(std::string headers, std::string body, Client* client);
 
   int max_fd_;
   fd_set rfd_set_, wfd_set_;

--- a/test/CGITest.cpp
+++ b/test/CGITest.cpp
@@ -11,7 +11,7 @@ class CGITest : public testing::Test {
   virtual void TearDown() {}
 
   void ExpectArgs(CGI& res) {
-    EXPECT_STREQ(res.GetArgs()[0], "./docs/chunked.cgi");
+    EXPECT_STREQ(res.GetArgs()[0], "./docs/perl.cgi");
     EXPECT_STREQ(res.GetArgs()[1], "mcgee");
     EXPECT_STREQ(res.GetArgs()[2], "mine");
   }


### PR DESCRIPTION
CGIの出力を受けるResponseクラスのパーサーを修正しました。
CGIの出力を都度`Response.AppendRawData(readbuf)`で追加してください。
出力の読み込みが完了した（`read() == 0`となる）タイミングで`Response.EndCGI()`を呼び出してください。