### PR TITLE
Error response

### DIFF
--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -88,7 +88,7 @@ void Client::Prepare(void) {
   int ret;
   ret = READ_FILE;
   // ret = WRITE_FILE;
-  ret = WRITE_CGI;
+  // ret = WRITE_CGI;
   // ret = WRITE_CLIENT;
   SetStatus((enum SocketStatus)ret);
 

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -11,7 +11,7 @@
 
 const int Client::buf_max_ = 8192;
 
-Client::Client(const struct config::Config& config) : config_(config) {
+Client::Client(const struct config::Config &config) : config_(config) {
   socket_status_ = READ_CLIENT;
 }
 
@@ -141,6 +141,10 @@ int Client::recv(int client_fd) {
   if (ret == 0) return ret;   // closed by client
 
   request_.AppendRawData(buf);
+  if (request_.GetStatus() == HttpMessage::DONE && !IsValidRequest()) {
+    response_.ErrorResponse(400);
+    SetStatus(WRITE_CLIENT);
+  }
 
   return 1;
 }
@@ -198,4 +202,10 @@ void Client::GenProcessForCGI(void) {
   read_fd_ = pipe_read[0];
   fcntl(read_fd_, F_SETFL, O_NONBLOCK);
   close(pipe_read[1]);
+}
+
+// TODO
+bool Client::IsValidRequest(void) {
+  if (request_.GetMethod() != GET) return false;
+  return true;
 }

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -142,7 +142,7 @@ int Client::recv(int client_fd) {
 
   request_.AppendRawData(buf);
   if (request_.GetStatus() == HttpMessage::DONE && !IsValidRequest()) {
-    response_.ErrorResponse(400);
+    response_.ErrorResponse(405);
     SetStatus(WRITE_CLIENT);
   }
 

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -3,6 +3,7 @@
 
 #include <sys/stat.h>
 
+#include <stdexcept>
 #include <vector>
 
 #include "ISocket.hpp"
@@ -17,7 +18,7 @@ typedef struct fileinfo {
 
 class Client : public Socket {
  public:
-  Client(const struct config::Config& config);
+  Client(const struct config::Config &config);
 
   int SetSocket(int _fd);
   void Prepare(void);
@@ -64,7 +65,14 @@ class Client : public Socket {
 
   int write_fd_;
   int read_fd_;
-  const config::Config& config_;
+
+  const config::Config &config_;
+
+ public:
+  class HttpResponseException : public std::runtime_error {
+   public:
+    HttpResponseException(const std::string &what) : std::runtime_error(what) {}
+  };
 };
 
 #endif /* CLIENT_HPP */

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -60,6 +60,8 @@ class Client : public Socket {
   void SetPipe(int *pipe_write, int *pipe_read);
   void ExecCGI(int *pipe_write, int *pipe_read, char **args, char **envs);
 
+  bool IsValidRequest();
+
   Request request_;
   Response response_;
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -107,7 +107,7 @@ void Response::Clear() {
   SetStatusCode(200);
   AppendHeader("Content-Type", "");
   AppendHeader("Date", Now());
-  AppendHeader("Server", "webserv");
+  AppendHeader("Server", "webserv/0.4.2");
 }
 
 void Response::SetStatusMessage(const std::string& msg) {
@@ -135,8 +135,6 @@ void Response::ErrorResponse(int status) {
   SetStatusCode(status);
   AppendBody(ErrorHtml(status));
   AppendHeader("Content-Type", "text/html");
-  AppendHeader("Date", Now());
-  AppendHeader("Server", "webserv");
   AppendHeader("Connection", "keep-alive");
   AppendHeader("Content-Length", ft::ltoa(body_.size()));
 }
@@ -146,8 +144,9 @@ std::string Response::ErrorHtml(int status) {
   body += ErrorStatusLine(status);
   body += "</title></head>\n<body>\n<center><h1>";
   body += ErrorStatusLine(status);
-  body +=
-      "</h1></center>\n<hr><center>webserv/0.4.2</center>\n</body>\n</html>\n";
+  body += "</h1></center>\n<hr><center>";
+  body += GetHeader("Server");
+  body += "</center>\n</body>\n</html>\n";
   return body;
 }
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,5 +1,7 @@
 #include "Response.hpp"
 
+#include <sstream>
+
 Response::Status::Status() {
   code[100] = "Continue";
   code[101] = "Swithing Protocol";
@@ -126,4 +128,31 @@ void Response::ParseBody() {
     AppendBody(raw_);
     raw_ = "";
   }
+}
+
+void Response::ErrorResponse(int status) {
+  Clear();
+  SetStatusCode(status);
+  AppendBody(ErrorHtml(status));
+  AppendHeader("Content-Type", "text/html");
+  AppendHeader("Date", Now());
+  AppendHeader("Server", "webserv");
+  AppendHeader("Connection", "keep-alive");
+  AppendHeader("Content-Length", ft::ltoa(body_.size()));
+}
+
+std::string Response::ErrorHtml(int status) {
+  std::string body = "<html>\n<head><title>";
+  body += ErrorStatusLine(status);
+  body += "</title></head>\n<body>\n<center><h1>";
+  body += ErrorStatusLine(status);
+  body +=
+      "</h1></center>\n<hr><center>webserv/0.4.2</center>\n</body>\n</html>\n";
+  return body;
+}
+
+std::string Response::ErrorStatusLine(int status) {
+  std::stringstream s;
+  s << status << " " << kResponseStatus.code.find(status)->second;
+  return (s.str());
 }

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -33,6 +33,7 @@ class Response : public HttpMessage {
   void EndCGI();
   std::string Str() const;
   void Clear();
+  void ErrorResponse(int status);
 
   class StatusException : public std::domain_error {
    public:
@@ -45,6 +46,9 @@ class Response : public HttpMessage {
   virtual void ParseStartline();
   virtual void ParseHeader();
   virtual void ParseBody();
+
+  std::string ErrorHtml(int status);
+  std::string ErrorStatusLine(int status);
 };
 
 #endif /* RESPONSE_HPP */

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -31,13 +31,12 @@ void WebServ::ParseConfig(const std::string &path) {
   config::Parser parser(path);
 
   std::vector<struct config::Config> configs = parser.GetConfigs();
-  if (configs.empty())
-    return;
+  if (configs.empty()) return;
 
   std::vector<struct config::Config>::const_iterator itr;
   for (itr = configs.begin(); itr != configs.end(); ++itr) {
     Server *server = new Server(*itr);
-    long fd = server->SetSocket(); // 42 is meaningless
+    int fd = server->SetSocket();
     sockets_[fd] = server;
   }
 }
@@ -47,7 +46,7 @@ int WebServ::AcceptSession(socket_iter it) {
   int server_fd = it->first;
 
   if (FD_ISSET(server_fd, &rfd_set_)) {
-    Server* server = dynamic_cast<Server *>(it->second);
+    Server *server = dynamic_cast<Server *>(it->second);
     Client *client = new Client(server->GetConfig());
 
     int client_fd = client->SetSocket(server_fd);
@@ -113,6 +112,11 @@ int WebServ::ReadFile(socket_iter it) {
 
     case 0:  // read complete
       close(client->GetReadFd());
+
+      // TODO: エラーレスポンスのヘッダーとかぶるから消したい。
+      client->AppendResponseHeader(
+          "Content-Length", ft::ltoa(client->GetResponse().GetBody().length()));
+
       client->SetStatus(WRITE_CLIENT);
       break;
 
@@ -156,6 +160,11 @@ int WebServ::ReadCGI(socket_iter it) {
   client->AppendResponseRawData(buf, ret);
   if (ret == 0) {
     close(client->GetReadFd());
+
+    // TODO: エラーレスポンスのヘッダーとかぶるから消したい。
+    client->AppendResponseHeader(
+        "Content-Length", ft::ltoa(client->GetResponse().GetBody().length()));
+
     client->SetStatus(WRITE_CLIENT);
   }
   return ret;
@@ -178,9 +187,6 @@ int WebServ::WriteClient(socket_iter it) {
   int client_fd = it->first;
   Client *client = dynamic_cast<Client *>(sockets_[client_fd]);
   int ret = -1;
-
-  client->AppendResponseHeader(
-      "Content-Length", ft::ltoa(client->GetResponse().GetBody().length()));
 
   // 完成したレスポンスを送る
   ret = client->send(client_fd);

--- a/test/http/httptest
+++ b/test/http/httptest
@@ -42,7 +42,7 @@ class Case():
 		else:
 			print(Color.RED + "status_code KO!" + Color.END)
 			exit(1)
-	
+
 	# bodyが期待と同じか
 	def body(self, expected):
 		if expected == self.r.text:
@@ -50,7 +50,7 @@ class Case():
 		else:
 			print(Color.RED + "body KO!" + Color.END)
 			exit(1)
-	
+
 	# bodyが期待の文字列を含むか
 	def body_has(self, expected):
 		if expected in self.r.text:
@@ -58,7 +58,7 @@ class Case():
 		else:
 			print(Color.RED + "body_has KO!" + Color.END)
 			exit(1)
-	
+
 	# headersに期待のkeyと同じ かつ 期待のvalueが同じものがあるか
 	def header(self, expected_key, expected_val):
 		if expected_key in self.r.headers and self.r.headers[expected_key] == expected_val:
@@ -102,8 +102,10 @@ case.header_has("Content-Length")
 
 ################################################################
 
+"""
 payload = {"key1": "val1", "key2": "val2"}
 case = Case("post", "http://localhost:4200", data=payload)
 case.status_code(200)
 case.body_has("mcgee")
 case.header_has("Content-Length")
+"""


### PR DESCRIPTION
エラーレスポンス（デフォルトの質素なやつ）を返せるようにしました。
とりあえずリクエストのメソッドがGET以外（POSTなど）の場合にエラーレスポンス（405）を返すようにしています。
また、 #37 にあげた内容の影響で、レスポンスステータスコードとレスポンスヘッダーの内容が上書きと追記されてしまっています。
#37 が解消されれば、正しく挙動することを確認しました。
このPRで行っていない理由は、正常なレスポンスを返す際のヘッダーやステータスの上書きを`Client.Prepare`などで行っているため、正常なレスポンスが返らなくなってしまうからです。
今回のチケットとは範囲が大きく異なってしまうため、放置しました。その辺りはissueの解消で修正したいです。

また、HTTPテストもその影響でパスしないようになっているので、POSTを試すテストはコメントアウトしています。