### PR TITLE
Config Getter

### DIFF
--- a/srcs/config.cpp
+++ b/srcs/config.cpp
@@ -1,4 +1,5 @@
 #include "config.hpp"
+#include "Client.hpp"
 #include <algorithm>
 
 namespace {
@@ -149,21 +150,13 @@ const struct Location* Config::MatchLocation(const std::string& uri) const {
         longest_prefix = &*itr;
     }
   }
+  if (longest_prefix == NULL)
+    throw Client::HttpResponseException("no matching location found");
   return longest_prefix;
-  //
-  // std::vector<const struct Location*> selected;
-  // for (std::vector<const struct Location>::const_iterator itr =
-  //          server_.locations.begin();
-  //      itr != server_.locations.end(); ++itr) {
-  //   if (uri.find(itr->path) == 0) selected.push_back(&*itr);
-  // }
-  // if (selected.empty()) return NULL;
-  // return *std::max_element(selected.begin(), selected.end(), CompareLocations);
 }
 
 bool Config::GetAutoindex(const std::string& uri) const {
   const struct Location* location = MatchLocation(uri);
-  // TODO: NULL
   return location->autoindex;
 }
 

--- a/srcs/config.cpp
+++ b/srcs/config.cpp
@@ -1,4 +1,5 @@
 #include "config.hpp"
+#include <algorithm>
 
 namespace {
 
@@ -130,6 +131,86 @@ int Config::GetPort() const {
 
 std::string Config::GetHost() const {
   return server_.host;
+}
+
+std::string Config::GetServerName() const {
+  return server_.server_name;
+}
+
+const struct Location* Config::MatchLocation(const std::string& uri) const {
+  if (server_.locations.empty()) throw std::runtime_error("no location specified");
+  const struct Location* longest_prefix = NULL;
+  std::vector<const struct Location>::const_iterator itr;
+  for (itr = server_.locations.begin(); itr != server_.locations.end(); ++itr) {
+    if (uri.find(itr->path) == 0) {
+      if (longest_prefix == NULL)
+        longest_prefix = &*itr;
+      else if (itr->path.length() > longest_prefix->path.length())
+        longest_prefix = &*itr;
+    }
+  }
+  return longest_prefix;
+  //
+  // std::vector<const struct Location*> selected;
+  // for (std::vector<const struct Location>::const_iterator itr =
+  //          server_.locations.begin();
+  //      itr != server_.locations.end(); ++itr) {
+  //   if (uri.find(itr->path) == 0) selected.push_back(&*itr);
+  // }
+  // if (selected.empty()) return NULL;
+  // return *std::max_element(selected.begin(), selected.end(), CompareLocations);
+}
+
+bool Config::GetAutoindex(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  // TODO: NULL
+  return location->autoindex;
+}
+
+int Config::GetClientMaxBodySize(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->client_max_body_size;
+}
+
+std::string Config::GetAlias(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->alias;
+}
+
+std::string Config::GetUploadPass(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->upload_pass;
+}
+
+std::string Config::GetUploadStore(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->upload_store;
+}
+
+std::set<std::string> Config::GetExtensions(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->extensions;
+}
+
+std::set<std::string> Config::GetIndexes(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->indexes;
+}
+
+std::map<int, std::string> Config::GetErrorPages(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->error_pages;
+}
+
+std::set<enum Method> Config::GetAllowedMethods(const std::string& uri) const {
+
+  const struct Location* location = MatchLocation(uri);
+  return location->allowed_methods;
+}
+
+std::pair<int, std::string> Config::GetRedirect(const std::string& uri) const {
+  const struct Location* location = MatchLocation(uri);
+  return location->redirect;
 }
 
 Parser::Parser(const std::string& filename) : filename_(filename) {

--- a/srcs/config.hpp
+++ b/srcs/config.hpp
@@ -69,11 +69,6 @@ struct Location {
   std::pair<int, std::string> redirect;
 };
 
-inline bool CompareLocations(const struct Location* a,
-                             const struct Location* b) {
-  return a->path.length() < b->path.length();
-}
-
 class Config {
  public:
   Config(const struct Server& server);

--- a/srcs/config.hpp
+++ b/srcs/config.hpp
@@ -69,6 +69,11 @@ struct Location {
   std::pair<int, std::string> redirect;
 };
 
+inline bool CompareLocations(const struct Location* a,
+                             const struct Location* b) {
+  return a->path.length() < b->path.length();
+}
+
 class Config {
  public:
   Config(const struct Server& server);
@@ -78,9 +83,23 @@ class Config {
 
   int GetPort() const;
   std::string GetHost() const;
+  std::string GetServerName() const;
+
+  bool GetAutoindex(const std::string& uri) const;
+  int GetClientMaxBodySize(const std::string& uri) const;
+  std::string GetAlias(const std::string& uri) const;
+  std::string GetUploadPass(const std::string& uri) const;
+  std::string GetUploadStore(const std::string& uri) const;
+  std::set<std::string> GetExtensions(const std::string& uri) const;
+  std::set<std::string> GetIndexes(const std::string& uri) const;
+  std::map<int, std::string> GetErrorPages(const std::string& uri) const;
+  std::set<enum Method> GetAllowedMethods(const std::string& uri) const;
+  std::pair<int, std::string> GetRedirect(const std::string& uri) const;
 
  private:
   struct Server server_;
+
+  const struct Location* MatchLocation(const std::string& uri) const;
 };
 
 struct LineComponent;


### PR DESCRIPTION
### 変更点
リクエストのuriから適切なLocationを探し、configの情報を取得する関数を作りました。

複数Locationがマッチした場合、最も長いプレフィックスを持ったLocationを選びます。
とりあえずマッチがなかった場合、`HttpResponseException`を投げています。

### 例
```
server {
	client_max_body_size 0;
	listen 4200;
	location / {
		autoindex on;
		client_max_body_size 1;
	}
	location /i/ {
		alias /data/w3/images/;
		client_max_body_size 2;
	}
	location /images/ {
		client_max_body_size 3;
	}
}
```
`localhost:4200`の場合、client_max_body_sizeは1
`localhost:4200/i`の場合、client_max_body_sizeは1
`localhost:4200/i/top.gif`の場合、client_max_body_sizeは2
`localhost:4200/i/images/top.gif`の場合、client_max_body_sizeは2
`localhost:4200/images/i/top.gif`の場合、client_max_body_sizeは3

### 参考
http://nginx.org/en/docs/beginners_guide.html
> If there are several matching location blocks nginx selects the one with the longest prefix. 