### PR TITLE
Refactoring

### DIFF
--- a/conf/basic.conf
+++ b/conf/basic.conf
@@ -10,7 +10,7 @@ error_page 404 ./docs/html/404.html;
 error_page 500 502 503 504 ./docs/html/50x.html;
 
 server {
-	listen 8008;
+	listen 80;
 	server_name server1.com;
 	index index.htm index.html index_server1.html;
 	autoindex off;

--- a/conf/basic.conf
+++ b/conf/basic.conf
@@ -1,84 +1,13 @@
-# basic conf
-
-# print_config on;
-
-index index.html;
-autoindex on;
-client_max_body_size 0;
-
-error_page 404 ./docs/html/404.html;
-error_page 500 502 503 504 ./docs/html/50x.html;
+error_page 405 ./docs/html/50x.html;
 
 server {
-	listen 8008;
-	server_name server1.com;
-	index index.htm index.html index_server1.html;
-	autoindex off;
-	client_max_body_size 1000;
-	# return 301 http://www.example.org/index.asp;
-	error_page 404 ./docs/html/404_server1.html;
-	ext .php .py;
-
-	location / {
-		alias ./docs/html/;
-		allowed_methods GET POST DELETE;
-		client_max_body_size 1001;
-	}
-
-	location /kapouet/ {
-		alias ./docs/html/;
-		allowed_methods GET;
-		index index_server1_kapouet.html;
-		autoindex on;
-		client_max_body_size 1002;
-		error_page 404 ./docs/html/404_server1_kapouet.html;
-		return 301 http://www.example.org/index.asp;
-	}
-
-	location /images/ {
-		alias /var/www/images/;
-		allowed_methods GET;
-
-		client_max_body_size 1003;
-		autoindex off;
-	}
-
-	location /cgi/ {
-		alias ./docs/;
-		allowed_methods GET POST;
-
-		client_max_body_size 1003;
-		autoindex off;
-	}
+	listen 4200;
 }
 
 server {
-	listen 8080;
-	server_name server2.com;
+	listen 4201;
+}
 
-	index index_server2.html;
-	autoindex off;
-
-	client_max_body_size 2000;
-
-	# return 301 http://www.example.org/index.asp;
-
-	error_page 404 ./docs/html/404_server2.html;
-	upload_pass /upload;
-	upload_store /upload;
-
-	location / {
-		alias ./docs/;
-		allowed_methods GET POST;
-
-		client_max_body_size 2001;
-		autoindex on;
-	}
-
-	location /test/ {
-		alias ./docs/;
-		allowed_methods GET POST;
-		index index_server2_test.html;
-		autoindex on;
-	}
+server {
+	listen 4202;
 }

--- a/conf/basic.conf
+++ b/conf/basic.conf
@@ -10,7 +10,7 @@ error_page 404 ./docs/html/404.html;
 error_page 500 502 503 504 ./docs/html/50x.html;
 
 server {
-	listen 80;
+	listen 8008;
 	server_name server1.com;
 	index index.htm index.html index_server1.html;
 	autoindex off;

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,13 +1,88 @@
-error_page 405 ./docs/html/50x.html;
+# basic conf
+
+# print_config on;
+
+index index.html;
+autoindex on;
+client_max_body_size 0;
+
+error_page 404 ./docs/html/404.html;
+error_page 500 502 503 504 ./docs/html/50x.html;
 
 server {
-	listen 4200;
+	listen 80;
+	server_name server1.com;
+
+	index index.htm index.html index_server1.html;
+	autoindex off;
+
+	client_max_body_size 1000;
+
+	# return 301 http://www.example.org/index.asp;
+
+	error_page 404 ./docs/html/404_server1.html;
+	ext .php .py;
+
+	location / {
+		alias ./docs/html/;
+		allowed_methods GET POST DELETE;
+		client_max_body_size 1001;
+	}
+
+	location /kapouet/ {
+		alias ./docs/html/;
+		allowed_methods GET;
+		index index_server1_kapouet.html;
+		autoindex on;
+		client_max_body_size 1002;
+		error_page 404 ./docs/html/404_server1_kapouet.html;
+		return 301 http://www.example.org/index.asp;
+	}
+
+	location /images/ {
+		alias /var/www/images/;
+		allowed_methods GET;
+
+		client_max_body_size 1003;
+		autoindex off;
+	}
+
+	location /cgi/ {
+		alias ./docs/;
+		allowed_methods GET POST;
+
+		client_max_body_size 1003;
+		autoindex off;
+	}
 }
 
 server {
-	listen 4201;
-}
+	listen 8080;
+	server_name server2.com;
 
-server {
-	listen 4202;
+	index index_server2.html;
+	autoindex off;
+
+	client_max_body_size 2000;
+
+	# return 301 http://www.example.org/index.asp;
+
+	error_page 404 ./docs/html/404_server2.html;
+	upload_pass /upload;
+	upload_store /upload;
+
+	location / {
+		alias ./docs/;
+		allowed_methods GET POST;
+
+		client_max_body_size 2001;
+		autoindex on;
+	}
+
+	location /test/ {
+		alias ./docs/;
+		allowed_methods GET POST;
+		index index_server2_test.html;
+		autoindex on;
+	}
 }

--- a/srcs/CGI.cpp
+++ b/srcs/CGI.cpp
@@ -1,12 +1,34 @@
 #include "CGI.hpp"
 
-#include <string.h>
-
-#include <vector>
-
 const int CGI::num_envs_ = 19;
 
 const std::string CGI::methods_[4] = {"GET", "POST", "DELETE", "INVALID"};
+
+CGI::CGI(const Request &request, int client_port, std::string client_host,
+         const config::Config &config, const std::string &path_translated)
+    : request_(request),
+      client_port_(client_port),
+      client_host_(client_host),
+      path_translated_(path_translated),
+      config_(config) {
+  SetArgs();
+  SetEnvs();
+}
+
+CGI::~CGI() {
+  int i = 0;
+
+  while (args_[i]) {
+    free(args_[i++]);
+  }
+  free(args_);
+
+  i = 0;
+  while (envs_[i]) {
+    free(envs_[i++]);
+  }
+  free(envs_);
+}
 
 void CGI::SetArgs() {
   std::vector<std::string> request_uri = ft::vsplit(
@@ -22,6 +44,53 @@ void CGI::SetArgs() {
   // args_ = ft::split(splited, '+');
 
   args_ = ft::split("./docs/perl.cgi+mcgee+mine", '+');
+}
+
+void CGI::SetEnvs() {
+  CalcEnvs();
+
+  std::string tmp;
+  int i = 0;
+  envs_ = (char **)malloc(sizeof(char *) * CGI::num_envs_);
+
+  tmp = "AUTH_TYPE=" + envs_map_["AUTH_TYPE"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "CONTENT_LENGTH=" + envs_map_["CONTENT_LENGTH"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "CONTENT_TYPE=" + envs_map_["CONTENT_TYPE"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "GATEWAY_INTERFACE=" + envs_map_["GATEWAY_INTERFACE"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "PATH_INFO=" + envs_map_["PATH_INFO"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "PATH_TRANSLATED=" + envs_map_["PATH_TRANSLATED"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "QUERY_STRING=" + envs_map_["QUERY_STRING"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REMOTE_ADDR=" + envs_map_["REMOTE_ADDR"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REMOTE_PORT=" + envs_map_["REMOTE_PORT"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REMOTE_IDENT=" + envs_map_["REMOTE_IDENT"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REMOTE_USER=" + envs_map_["REMOTE_USER"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REQUEST_METHOD=" + envs_map_["REQUEST_METHOD"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "REQUEST_URI=" + envs_map_["REQUEST_URI"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "SCRIPT_NAME=" + envs_map_["SCRIPT_NAME"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "SERVER_NAME=" + envs_map_["SERVER_NAME"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "SERVER_PORT=" + envs_map_["SERVER_PORT"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "SERVER_PROTOCOL=" + envs_map_["SERVER_PROTOCOL"];
+  envs_[i++] = strdup(tmp.c_str());
+  tmp = "SERVER_SOFTWARE=" + envs_map_["SERVER_SOFTWARE"];
+  envs_[i++] = strdup(tmp.c_str());
+
+  envs_[i] = NULL;
 }
 
 void CGI::CalcEnvs() {
@@ -74,77 +143,4 @@ void CGI::CalcEnvs() {
   envs_map_["SERVER_PORT"] = ft::ltoa(config_.GetPort());
   envs_map_["SERVER_PROTOCOL"] = "HTTP/1.1";
   envs_map_["SERVER_SOFTWARE"] = "Webserv/0.4.2";
-}
-
-void CGI::SetEnvs() {
-  CalcEnvs();
-
-  std::string tmp;
-  int i = 0;
-  envs_ = (char **)malloc(sizeof(char *) * CGI::num_envs_);
-
-  tmp = "AUTH_TYPE=" + envs_map_["AUTH_TYPE"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "CONTENT_LENGTH=" + envs_map_["CONTENT_LENGTH"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "CONTENT_TYPE=" + envs_map_["CONTENT_TYPE"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "GATEWAY_INTERFACE=" + envs_map_["GATEWAY_INTERFACE"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "PATH_INFO=" + envs_map_["PATH_INFO"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "PATH_TRANSLATED=" + envs_map_["PATH_TRANSLATED"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "QUERY_STRING=" + envs_map_["QUERY_STRING"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REMOTE_ADDR=" + envs_map_["REMOTE_ADDR"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REMOTE_PORT=" + envs_map_["REMOTE_PORT"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REMOTE_IDENT=" + envs_map_["REMOTE_IDENT"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REMOTE_USER=" + envs_map_["REMOTE_USER"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REQUEST_METHOD=" + envs_map_["REQUEST_METHOD"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "REQUEST_URI=" + envs_map_["REQUEST_URI"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "SCRIPT_NAME=" + envs_map_["SCRIPT_NAME"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "SERVER_NAME=" + envs_map_["SERVER_NAME"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "SERVER_PORT=" + envs_map_["SERVER_PORT"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "SERVER_PROTOCOL=" + envs_map_["SERVER_PROTOCOL"];
-  envs_[i++] = strdup(tmp.c_str());
-  tmp = "SERVER_SOFTWARE=" + envs_map_["SERVER_SOFTWARE"];
-  envs_[i++] = strdup(tmp.c_str());
-
-  envs_[i] = NULL;
-}
-
-CGI::CGI(const Request &request, int client_port, std::string client_host,
-         const config::Config &config, const std::string &path_translated)
-    : request_(request),
-      client_port_(client_port),
-      client_host_(client_host),
-      path_translated_(path_translated),
-      config_(config) {
-  SetArgs();
-  SetEnvs();
-}
-
-CGI::~CGI() {
-  int i = 0;
-
-  while (args_[i]) {
-    free(args_[i++]);
-  }
-  free(args_);
-
-  i = 0;
-  while (envs_[i]) {
-    free(envs_[i++]);
-  }
-  free(envs_);
 }

--- a/srcs/CGI.hpp
+++ b/srcs/CGI.hpp
@@ -22,6 +22,7 @@ class CGI {
   char **GetEnvs() const { return envs_; };
 
  private:
+  /* prohibit copy constructor and assignment operator */
   CGI(const CGI &);
   CGI &operator=(const CGI &);
 

--- a/srcs/CGI.hpp
+++ b/srcs/CGI.hpp
@@ -1,7 +1,10 @@
 #ifndef CGI_HPP
 #define CGI_HPP
 
+#include <string.h>
+
 #include <map>
+#include <vector>
 
 #include "Request.hpp"
 #include "config.hpp"
@@ -19,6 +22,9 @@ class CGI {
   char **GetEnvs() const { return envs_; };
 
  private:
+  CGI(const CGI &);
+  CGI &operator=(const CGI &);
+
   void SetArgs();
   void SetEnvs();
   void CalcEnvs();

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -18,7 +18,7 @@ Client::Client(const config::Config &config) : config_(config) {
   sended_ = 0;
 }
 
-int Client::SetSocket(int _fd) {
+int Client::ConnectClientSocket(int _fd) {
   socklen_t len = sizeof(addr_);
   int fd = accept(_fd, (struct sockaddr *)&addr_, &len);
 

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -290,7 +290,6 @@ int Client::RecvRequest(int client_fd) {
   try {
     request_.AppendRawData(buf);
     if (request_.GetStatus() == HttpMessage::DONE) {
-      std::cout << "\nrecv from " << host_ip_ << ":" << port_ << std::endl;
       Preprocess();
     }
     if (request_.GetStatus() == HttpMessage::DONE && !IsValidRequest()) {
@@ -318,7 +317,7 @@ int Client::SendResponse(int client_fd) {
 
   sended_ += ret;
   if (sended_ >= response_.Str().size()) {
-    std::cout << "send to   " + host_ip_ << ":" << port_ << std::endl;
+    std::cout << LogMessage() << std::endl;
     response_.Clear();
     request_.Clear();
     sended_ = 0;
@@ -519,4 +518,21 @@ std::string Client::MakePathUri(std::string request_path,
   }
 
   return res;
+}
+
+std::string Client::LogMessage() const {
+  std::string method_array[4] = {"GET", "POST", "DELETE", "INVALID"};
+  std::stringstream ss;
+  ss << host_ip_;  // << ":" << port_;
+  ss << " - [" << response_.GetHeader("Date") << "] ";
+  ss << "\"" << method_array[request_.GetMethod()] << " ";
+  ss << request_.GetURI() << " ";
+  ss << "HTTP/" << request_.GetVersion() << "\" ";
+  ss << response_.GetStatusCode() << " ";
+  try {
+    ss << response_.GetHeader("Content-Length");
+    ss << " \"" << request_.GetHeader("User-Agent") << "\"";
+  } catch (std::exception &e) {
+  }
+  return ss.str();
 }

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -31,249 +31,6 @@ int Client::ConnectClientSocket(int _fd) {
   return fd;
 }
 
-bool Client::IsValidExtension(std::string path_uri, std::string request_path) {
-  size_t i = path_uri.length() - 1;
-
-  while (i > 0 && path_uri[i] != '.') --i;
-  std::string extension = path_uri.substr(i);
-
-  std::set<std::string> allowd_extensions;
-  allowd_extensions = config_.GetExtensions(request_path);
-
-  if (allowd_extensions.count(extension) == 1)
-    return true;
-  else
-    return false;
-}
-
-std::string Client::GetIndexFileIfExist(std::string path_uri,
-                                        std::string request_path) {
-  std::vector<std::string> conf_indexes = config_.GetIndexes(request_path);
-
-  for (size_t i = 0; i < conf_indexes.size(); ++i) {
-    struct stat buffer;
-    std::string filename = conf_indexes[i];
-
-    if (stat((path_uri + filename).c_str(), &buffer) != -1 &&
-        S_ISREG(buffer.st_mode)) {
-      return filename;
-    }
-  }
-  return "";
-}
-
-bool Client::IsValidUploadRequest(const std::string &request_path) {
-  std::string upload_pass = config_.GetUploadPass(request_path);
-  std::string upload_store = config_.GetUploadStore(request_path);
-
-  std::vector<std::string> request_splited = ft::vsplit(request_path, '/');
-  std::vector<std::string> upload_pass_splited = ft::vsplit(upload_pass, '/');
-
-  std::string upload_pass_full_path = MakePathUri(upload_pass, "/");
-  std::string upload_store_full_path = MakePathUri(upload_store, "/");
-
-  struct stat buffer;
-  if (stat((upload_pass_full_path).c_str(), &buffer) == -1) {
-    return false;
-  }
-  if (stat((upload_store_full_path).c_str(), &buffer) == -1) {
-    return false;
-  }
-  if (upload_pass_splited.size() > request_splited.size()) {
-    return false;
-  }
-
-  size_t i = 0;
-  while (i < upload_pass_splited.size()) {
-    if (request_splited[i] == upload_pass_splited[i]) {
-      ++i;
-    } else {
-      break;
-    }
-  }
-
-  return i == upload_pass_splited.size();
-}
-
-bool Client::DirectoryRedirect(std::string request_path) {
-  std::string location_path = config_.GetPath(request_path);
-  std::string path_uri = MakePathUri(request_path, location_path);
-
-  struct stat buffer;
-  if (stat((path_uri).c_str(), &buffer) == -1) {
-    throw ft::HttpResponseException("404");
-  }
-
-  if (S_ISDIR(buffer.st_mode) && request_path[request_path.size() - 1] != '/')
-    return true;
-  else
-    return false;
-}
-
-enum SocketStatus Client::HandleGET(std::string &path_uri) {
-  struct stat buffer;
-  if (stat((path_uri).c_str(), &buffer) == -1) {
-    throw ft::HttpResponseException("404");
-  }
-
-  std::string request_path = request_.GetURI();
-
-  // (CGI)
-  if (IsValidExtension(path_uri, request_path)) {
-    return READ_WRITE_CGI;
-  }
-
-  // (SIMPLE GET)
-  if (S_ISREG(buffer.st_mode)) {
-    return READ_FILE;
-  } else if (S_ISDIR(buffer.st_mode)) {
-    path_uri += "/";
-
-    std::string index_filename = GetIndexFileIfExist(path_uri, request_path);
-    if (index_filename.empty() == false) {
-      path_uri += index_filename;
-
-      // (CGI)
-      if (IsValidExtension(path_uri, request_path)) {
-        return READ_WRITE_CGI;
-      }
-
-      // (GET INDEX)
-      return READ_FILE;
-    } else if (config_.GetAutoindex(request_path) == true) {
-      // (AUTOINDEX)
-      return WRITE_CLIENT;
-    }
-  }
-
-  throw ft::HttpResponseException("404");
-}
-
-enum SocketStatus Client::HandlePOST(std::string &path_uri) {
-  struct stat buffer;
-  if (stat((path_uri).c_str(), &buffer) == -1) {
-    throw ft::HttpResponseException("404");
-  }
-
-  std::string request_path = request_.GetURI();
-
-  // (CGI)
-  if (IsValidExtension(path_uri, request_path)) {
-    return READ_WRITE_CGI;
-  }
-
-  // (UPLOAD)
-  if (!config_.GetUploadPass(request_path).empty() &&
-      !config_.GetUploadStore(request_path).empty()) {
-    if (IsValidUploadRequest(request_path)) {
-      std::string filename = std::string("/" + ft::what_time() + ".html");
-      std::string store = config_.GetUploadStore(request_path);
-      if (store[store.size() - 1] == '/')
-        store = store.substr(0, store.size() - 1);
-      path_uri = MakePathUri(store, "/") + filename;
-      response_.AppendHeader("Content-Location", store + filename);
-      return WRITE_FILE;
-    }
-  }
-
-  throw ft::HttpResponseException("405");
-}
-
-enum SocketStatus Client::HandleDELETE(std::string &path_uri) {
-  struct stat buffer;
-  if (stat((path_uri).c_str(), &buffer) == -1) {
-    throw ft::HttpResponseException("404");
-  }
-
-  remove((path_uri).c_str());
-  return WRITE_CLIENT;
-}
-
-enum SocketStatus Client::GetNextOfReadClient(std::string &path_uri) {
-  enum SocketStatus ret = WRITE_CLIENT;
-
-  std::string request_path = request_.GetURI();
-  std::string location_path = config_.GetPath(request_path);
-
-  path_uri = MakePathUri(request_path, location_path);
-  enum Method method = request_.GetMethod();
-
-  if (config_.GetAllowedMethods(request_path).count(method) == 0) {
-    throw ft::HttpResponseException("405");
-  }
-
-  switch (method) {
-    case GET:
-      ret = HandleGET(path_uri);
-      break;
-    case POST:
-      ret = HandlePOST(path_uri);
-      break;
-    case DELETE:
-      ret = HandleDELETE(path_uri);
-      break;
-    default:
-      break;
-  }
-
-  return ret;
-}
-
-void Client::Preprocess(void) {
-  if (socket_status_ != READ_CLIENT) return;
-
-  enum SocketStatus ret;
-  std::string path_uri;
-
-  std::string request_path = request_.GetURI();
-  std::pair<int, std::string> redirect;
-
-  try {  // this is the first time config getter is used
-    redirect = config_.GetRedirect(request_path);
-  } catch (const std::exception &e) {
-    throw ft::HttpResponseException("404");
-  }
-
-  if (redirect.first == 0 && redirect.second.empty() &&
-      DirectoryRedirect(request_path)) {
-    redirect.first = 301;
-    redirect.second = "http://" + config_.GetHost() + ":" +
-                      ft::ltoa(config_.GetPort()) + request_path + "/";
-  }
-
-  // no redirect
-  if (redirect.first == 0 && redirect.second.empty()) {
-    ret = GetNextOfReadClient(path_uri);
-    socket_status_ = ret;
-  } else {
-    ret = WRITE_CLIENT;
-    socket_status_ = ret;
-  }
-
-  if (ret == READ_FILE) {
-    if ((read_fd_ = open(path_uri.c_str(), O_RDONLY)) < 0)
-      throw ft::HttpResponseException("403");
-    if (fcntl(read_fd_, F_SETFL, O_NONBLOCK) == -1)
-      throw ft::HttpResponseException("500");
-  } else if (ret == WRITE_FILE) {
-    if ((write_fd_ = open(path_uri.c_str(), O_RDWR | O_CREAT, 0644)) < 0)
-      throw ft::HttpResponseException("403");
-    if (fcntl(write_fd_, F_SETFL, O_NONBLOCK) < 0)
-      throw ft::HttpResponseException("500");
-  } else if (ret == READ_WRITE_CGI) {
-    GenProcessForCGI(path_uri);
-  } else if (ret == WRITE_CLIENT) {
-    if (!(redirect.first == 0 && redirect.second.empty())) {  // redirect
-      response_.RedirectResponse(redirect.first, redirect.second);
-    } else if (request_.GetMethod() == DELETE) {  // DELETE
-      response_.DeleteResponse();
-    } else if (config_.GetAutoindex(request_path)) {  // autoindex
-      response_.AutoIndexResponse(path_uri.c_str(), request_path);
-    } else
-      throw ft::HttpResponseException("405");
-  }
-}
-
 int Client::RecvRequest(int client_fd) {
   int ret;
   char buf[buf_max_] = {0};
@@ -287,9 +44,6 @@ int Client::RecvRequest(int client_fd) {
     request_.AppendRawData(buf);
     if (request_.GetStatus() == HttpMessage::DONE) {
       Preprocess();
-    }
-    if (request_.GetStatus() == HttpMessage::DONE && !IsValidRequest()) {
-      throw ft::HttpResponseException("405");
     }
   } catch (const Request::RequestFatalException &e) {
     std::cout << "RequestFatalException: " << e.what() << std::endl;
@@ -400,28 +154,87 @@ void Client::WriteCGIin() {
   }
 }
 
-void Client::SetPipe(int *pipe_write, int *pipe_read) {
-  if (pipe(pipe_write) == -1) throw ft::HttpResponseException("500");
-  if (pipe(pipe_read) == -1) throw ft::HttpResponseException("500");
+int Client::GetStatus() const { return socket_status_; }
+
+int Client::GetWriteFd() const { return write_fd_; }
+
+int Client::GetReadFd() const { return read_fd_; }
+
+void Client::HandleException(const char *err_msg) {
+  int status_code = std::atoi(err_msg);
+  try {
+    std::map<int, std::string> error_pages =
+        config_.GetErrorPages(request_.GetURI());
+    for (std::map<int, std::string>::iterator i = error_pages.begin();
+         i != error_pages.end(); ++i) {
+      if (status_code == i->first) {
+        response_.SetStatusCode(status_code);
+        if ((read_fd_ = open(i->second.c_str(), O_RDONLY)) < 0) break;
+        if (fcntl(read_fd_, F_SETFL, O_NONBLOCK) == -1) break;
+        socket_status_ = READ_FILE;
+        return;
+      }
+    }
+  } catch (ft::ConfigException &e) {
+    std::cerr << "config: " << e.what() << std::endl;
+  }
+  response_.ErrorResponse(status_code);
+  socket_status_ = WRITE_CLIENT;
 }
 
-void Client::ExecCGI(int *pipe_write, int *pipe_read, const CGI &cgi,
-                     const std::string &path_uri) {
-  char **args = cgi.GetArgs();
-  char **envs = cgi.GetEnvs();
+void Client::Preprocess(void) {
+  if (socket_status_ != READ_CLIENT) return;
 
-  if (dup2(pipe_write[0], STDIN_FILENO) == -1)
-    throw ft::HttpResponseException("500");
-  if (dup2(pipe_read[1], STDOUT_FILENO) == -1)
-    throw ft::HttpResponseException("500");
+  enum SocketStatus ret;
+  std::string path_uri;
 
-  close(pipe_write[0]);
-  close(pipe_write[1]);
-  close(pipe_read[0]);
-  close(pipe_read[1]);
+  std::string request_path = request_.GetURI();
+  std::pair<int, std::string> redirect;
 
-  execve(path_uri.c_str(), args, envs);
-  exit(EXIT_FAILURE);
+  try {  // this is the first time config getter is used
+    redirect = config_.GetRedirect(request_path);
+  } catch (const std::exception &e) {
+    throw ft::HttpResponseException("404");
+  }
+
+  if (redirect.first == 0 && redirect.second.empty() &&
+      DirectoryRedirect(request_path)) {
+    redirect.first = 301;
+    redirect.second = "http://" + config_.GetHost() + ":" +
+                      ft::ltoa(config_.GetPort()) + request_path + "/";
+  }
+
+  // no redirect
+  if (redirect.first == 0 && redirect.second.empty()) {
+    ret = GetNextOfReadClient(path_uri);
+    socket_status_ = ret;
+  } else {
+    ret = WRITE_CLIENT;
+    socket_status_ = ret;
+  }
+
+  if (ret == READ_FILE) {
+    if ((read_fd_ = open(path_uri.c_str(), O_RDONLY)) < 0)
+      throw ft::HttpResponseException("403");
+    if (fcntl(read_fd_, F_SETFL, O_NONBLOCK) == -1)
+      throw ft::HttpResponseException("500");
+  } else if (ret == WRITE_FILE) {
+    if ((write_fd_ = open(path_uri.c_str(), O_RDWR | O_CREAT, 0644)) < 0)
+      throw ft::HttpResponseException("403");
+    if (fcntl(write_fd_, F_SETFL, O_NONBLOCK) < 0)
+      throw ft::HttpResponseException("500");
+  } else if (ret == READ_WRITE_CGI) {
+    GenProcessForCGI(path_uri);
+  } else if (ret == WRITE_CLIENT) {
+    if (!(redirect.first == 0 && redirect.second.empty())) {  // redirect
+      response_.RedirectResponse(redirect.first, redirect.second);
+    } else if (request_.GetMethod() == DELETE) {  // DELETE
+      response_.DeleteResponse();
+    } else if (config_.GetAutoindex(request_path)) {  // autoindex
+      response_.AutoIndexResponse(path_uri.c_str(), request_path);
+    } else
+      throw ft::HttpResponseException("405");
+  }
 }
 
 void Client::GenProcessForCGI(const std::string &path_uri) {
@@ -449,32 +262,137 @@ void Client::GenProcessForCGI(const std::string &path_uri) {
   close(pipe_read[1]);
 }
 
-// TODO
-bool Client::IsValidRequest(void) {
-  // if (request_.GetMethod() != GET) return false;
-  return true;
+void Client::SetPipe(int *pipe_write, int *pipe_read) {
+  if (pipe(pipe_write) == -1) throw ft::HttpResponseException("500");
+  if (pipe(pipe_read) == -1) throw ft::HttpResponseException("500");
 }
 
-void Client::HandleException(const char *err_msg) {
-  int status_code = std::atoi(err_msg);
-  try {
-    std::map<int, std::string> error_pages =
-        config_.GetErrorPages(request_.GetURI());
-    for (std::map<int, std::string>::iterator i = error_pages.begin();
-         i != error_pages.end(); ++i) {
-      if (status_code == i->first) {
-        response_.SetStatusCode(status_code);
-        if ((read_fd_ = open(i->second.c_str(), O_RDONLY)) < 0) break;
-        if (fcntl(read_fd_, F_SETFL, O_NONBLOCK) == -1) break;
-        socket_status_ = READ_FILE;
-        return;
-      }
-    }
-  } catch (ft::ConfigException &e) {
-    std::cerr << "config: " << e.what() << std::endl;
+void Client::ExecCGI(int *pipe_write, int *pipe_read, const CGI &cgi,
+                     const std::string &path_uri) {
+  char **args = cgi.GetArgs();
+  char **envs = cgi.GetEnvs();
+
+  if (dup2(pipe_write[0], STDIN_FILENO) == -1)
+    throw ft::HttpResponseException("500");
+  if (dup2(pipe_read[1], STDOUT_FILENO) == -1)
+    throw ft::HttpResponseException("500");
+
+  close(pipe_write[0]);
+  close(pipe_write[1]);
+  close(pipe_read[0]);
+  close(pipe_read[1]);
+
+  execve(path_uri.c_str(), args, envs);
+  exit(EXIT_FAILURE);
+}
+
+bool Client::IsValidExtension(std::string path_uri, std::string request_path) {
+  size_t i = path_uri.length() - 1;
+
+  while (i > 0 && path_uri[i] != '.') --i;
+  std::string extension = path_uri.substr(i);
+
+  std::set<std::string> allowd_extensions;
+  allowd_extensions = config_.GetExtensions(request_path);
+
+  if (allowd_extensions.count(extension) == 1)
+    return true;
+  else
+    return false;
+}
+
+bool Client::IsValidUploadRequest(const std::string &request_path) {
+  std::string upload_pass = config_.GetUploadPass(request_path);
+  std::string upload_store = config_.GetUploadStore(request_path);
+
+  std::vector<std::string> request_splited = ft::vsplit(request_path, '/');
+  std::vector<std::string> upload_pass_splited = ft::vsplit(upload_pass, '/');
+
+  std::string upload_pass_full_path = MakePathUri(upload_pass, "/");
+  std::string upload_store_full_path = MakePathUri(upload_store, "/");
+
+  struct stat buffer;
+  if (stat((upload_pass_full_path).c_str(), &buffer) == -1) {
+    return false;
   }
-  response_.ErrorResponse(status_code);
-  socket_status_ = WRITE_CLIENT;
+  if (stat((upload_store_full_path).c_str(), &buffer) == -1) {
+    return false;
+  }
+  if (upload_pass_splited.size() > request_splited.size()) {
+    return false;
+  }
+
+  size_t i = 0;
+  while (i < upload_pass_splited.size()) {
+    if (request_splited[i] == upload_pass_splited[i]) {
+      ++i;
+    } else {
+      break;
+    }
+  }
+
+  return i == upload_pass_splited.size();
+}
+
+bool Client::DirectoryRedirect(std::string request_path) {
+  std::string location_path = config_.GetPath(request_path);
+  std::string path_uri = MakePathUri(request_path, location_path);
+
+  struct stat buffer;
+  if (stat((path_uri).c_str(), &buffer) == -1) {
+    throw ft::HttpResponseException("404");
+  }
+
+  if (S_ISDIR(buffer.st_mode) && request_path[request_path.size() - 1] != '/')
+    return true;
+  else
+    return false;
+}
+
+std::string Client::GetIndexFileIfExist(std::string path_uri,
+                                        std::string request_path) {
+  std::vector<std::string> conf_indexes = config_.GetIndexes(request_path);
+
+  for (size_t i = 0; i < conf_indexes.size(); ++i) {
+    struct stat buffer;
+    std::string filename = conf_indexes[i];
+
+    if (stat((path_uri + filename).c_str(), &buffer) != -1 &&
+        S_ISREG(buffer.st_mode)) {
+      return filename;
+    }
+  }
+  return "";
+}
+
+enum SocketStatus Client::GetNextOfReadClient(std::string &path_uri) {
+  enum SocketStatus ret = WRITE_CLIENT;
+
+  std::string request_path = request_.GetURI();
+  std::string location_path = config_.GetPath(request_path);
+
+  path_uri = MakePathUri(request_path, location_path);
+  enum Method method = request_.GetMethod();
+
+  if (config_.GetAllowedMethods(request_path).count(method) == 0) {
+    throw ft::HttpResponseException("405");
+  }
+
+  switch (method) {
+    case GET:
+      ret = HandleGET(path_uri);
+      break;
+    case POST:
+      ret = HandlePOST(path_uri);
+      break;
+    case DELETE:
+      ret = HandleDELETE(path_uri);
+      break;
+    default:
+      break;
+  }
+
+  return ret;
 }
 
 std::string Client::MakePathUri(std::string request_path,
@@ -514,6 +432,85 @@ std::string Client::MakePathUri(std::string request_path,
   }
 
   return res;
+}
+
+enum SocketStatus Client::HandleGET(std::string &path_uri) {
+  struct stat buffer;
+  if (stat((path_uri).c_str(), &buffer) == -1) {
+    throw ft::HttpResponseException("404");
+  }
+
+  std::string request_path = request_.GetURI();
+
+  // (CGI)
+  if (IsValidExtension(path_uri, request_path)) {
+    return READ_WRITE_CGI;
+  }
+
+  // (SIMPLE GET)
+  if (S_ISREG(buffer.st_mode)) {
+    return READ_FILE;
+  } else if (S_ISDIR(buffer.st_mode)) {
+    path_uri += "/";
+
+    std::string index_filename = GetIndexFileIfExist(path_uri, request_path);
+    if (index_filename.empty() == false) {
+      path_uri += index_filename;
+
+      // (CGI)
+      if (IsValidExtension(path_uri, request_path)) {
+        return READ_WRITE_CGI;
+      }
+
+      // (GET INDEX)
+      return READ_FILE;
+    } else if (config_.GetAutoindex(request_path) == true) {
+      // (AUTOINDEX)
+      return WRITE_CLIENT;
+    }
+  }
+
+  throw ft::HttpResponseException("404");
+}
+
+enum SocketStatus Client::HandlePOST(std::string &path_uri) {
+  struct stat buffer;
+  if (stat((path_uri).c_str(), &buffer) == -1) {
+    throw ft::HttpResponseException("404");
+  }
+
+  std::string request_path = request_.GetURI();
+
+  // (CGI)
+  if (IsValidExtension(path_uri, request_path)) {
+    return READ_WRITE_CGI;
+  }
+
+  // (UPLOAD)
+  if (!config_.GetUploadPass(request_path).empty() &&
+      !config_.GetUploadStore(request_path).empty()) {
+    if (IsValidUploadRequest(request_path)) {
+      std::string filename = std::string("/" + ft::what_time() + ".html");
+      std::string store = config_.GetUploadStore(request_path);
+      if (store[store.size() - 1] == '/')
+        store = store.substr(0, store.size() - 1);
+      path_uri = MakePathUri(store, "/") + filename;
+      response_.AppendHeader("Content-Location", store + filename);
+      return WRITE_FILE;
+    }
+  }
+
+  throw ft::HttpResponseException("405");
+}
+
+enum SocketStatus Client::HandleDELETE(std::string &path_uri) {
+  struct stat buffer;
+  if (stat((path_uri).c_str(), &buffer) == -1) {
+    throw ft::HttpResponseException("404");
+  }
+
+  remove((path_uri).c_str());
+  return WRITE_CLIENT;
 }
 
 std::string Client::LogMessage() const {

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -247,7 +247,7 @@ void Client::GenProcessForCGI(const std::string &path_uri) {
   if ((pid = fork()) < 0)
     throw ft::HttpResponseException("500");
   else if (pid == 0) {
-    CGI cgi_vals = CGI(request_, port_, host_ip_, config_, path_uri);
+    CGI cgi_vals(request_, port_, host_ip_, config_, path_uri);
     ExecCGI(pipe_write, pipe_read, cgi_vals, path_uri);
   }
 

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -25,9 +25,10 @@ int Client::ConnectClientSocket(int _fd) {
   port_ = ntohs(addr_.sin_port);
   host_ip_ = ft::inet_ntoa(addr_.sin_addr);
 
-  if (fd == -1) throw std::runtime_error("accept error\n");
+  if (fd == -1)
+    throw std::runtime_error("accept: " + std::string(strerror(errno)));
   if (fcntl(fd, F_SETFL, O_NONBLOCK) != 0)
-    throw std::runtime_error("fcntl error\n");
+    throw std::runtime_error("fcntl: " + std::string(strerror(errno)));
   return fd;
 }
 

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -350,7 +350,7 @@ void Client::WriteStaticFile() {
       throw ft::HttpResponseException("500");
   }
 
-  EraseRequestBody(ret);
+  request_.EraseBody(ret);
   if (request_.GetBody().empty()) {
     close(write_fd_);
     response_.SetStatusCode(201);
@@ -392,7 +392,7 @@ void Client::WriteCGIin() {
     int ret = 0;
     if ((ret = write(write_fd_, request_.GetBody().c_str(), len)) < 0)
       throw ft::HttpResponseException("500");
-    EraseRequestBody(ret);
+    request_.EraseBody(ret);
   }
   if (request_.GetBody().empty()) {
     close(write_fd_);

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -1,16 +1,5 @@
 #include "Client.hpp"
 
-#include <dirent.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <unistd.h>
-
-#include <iostream>
-#include <stdexcept>
-#include <string>
-
-#include "utility.hpp"
-
 const int Client::buf_max_ = 8192;
 
 Client::Client(const config::Config &config) : config_(config) {

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -45,6 +45,9 @@ class Client : public Socket {
   void HandleException(const char *err_msg);
 
  private:
+  Client(const Client &client);
+  Client &operator=(const Client &client);
+
   void Preprocess(void);
   void GenProcessForCGI(const std::string &path_uri);
   void SetPipe(int *pipe_write, int *pipe_read);

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -1,13 +1,16 @@
 #ifndef CLIENT_HPP
 #define CLIENT_HPP
 
-#include <vector>
+#include <dirent.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 #include "CGI.hpp"
 #include "ISocket.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
 #include "config.hpp"
+#include "utility.hpp"
 
 #ifdef GOOGLE_TEST
 #include <gtest/gtest.h>

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -13,7 +13,7 @@
 #include <gtest/gtest.h>
 #endif
 
-class Client : public Socket {
+class Client : public ISocket {
 #ifdef GOOGLE_TEST
   FRIEND_TEST(ClientTest, IsValidExtension);
   FRIEND_TEST(ClientTest, GetIndexFileIfExist);

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -45,6 +45,7 @@ class Client : public ISocket {
   void HandleException(const char *err_msg);
 
  private:
+  /* prohibit copy constructor and assignment operator */
   Client(const Client &client);
   Client &operator=(const Client &client);
 

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -45,7 +45,6 @@ class Client : public Socket {
   void HandleException(const char *err_msg);
 
  private:
-  void EraseRequestBody(ssize_t length) { request_.EraseBody(length); };
   void Preprocess(void);
   void GenProcessForCGI(const std::string &path_uri);
   void SetPipe(int *pipe_write, int *pipe_read);

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -37,9 +37,9 @@ class Client : public Socket {
   void WriteCGIin();
 
   // Getter
-  int GetStatus() const { return socket_status_; };
-  int GetWriteFd() const { return write_fd_; };
-  int GetReadFd() const { return read_fd_; };
+  int GetStatus() const;
+  int GetWriteFd() const;
+  int GetReadFd() const;
 
   // Exception handling
   void HandleException(const char *err_msg);
@@ -50,7 +50,7 @@ class Client : public Socket {
   void SetPipe(int *pipe_write, int *pipe_read);
   void ExecCGI(int *pipe_write, int *pipe_read, const CGI &cgi,
                const std::string &path_uri);
-  bool IsValidRequest();
+
   bool IsValidExtension(std::string path_uri, std::string request_path);
   bool IsValidUploadRequest(const std::string &request_path);
   bool DirectoryRedirect(std::string request_path);

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -59,13 +59,15 @@ class Client : public Socket {
   std::string GetIndexFileIfExist(std::string path_uri,
                                   std::string request_path);
   enum SocketStatus GetNextOfReadClient(std::string &path_uri);
-  std::string MakePathUri(std::string request_uri,
-                          std::string location_path);
+  std::string MakePathUri(std::string request_uri, std::string location_path);
 
   // method branching
   enum SocketStatus HandleGET(std::string &path_uri);
   enum SocketStatus HandlePOST(std::string &path_uri);
   enum SocketStatus HandleDELETE(std::string &path_uri);
+
+  // logging
+  std::string LogMessage() const;
 
   // member variables
   Request request_;

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -26,7 +26,7 @@ class Client : public Socket {
   Client(const config::Config &config);
 
   // Socket actions
-  int SetSocket(int _fd);
+  int ConnectClientSocket(int _fd);
 
   // I/O actions
   int RecvRequest(int client_fd);

--- a/srcs/Client.hpp
+++ b/srcs/Client.hpp
@@ -46,7 +46,6 @@ class Client : public Socket {
 
  private:
   void EraseRequestBody(ssize_t length) { request_.EraseBody(length); };
-  void SetEventStatus(enum SocketStatus status);
   void Preprocess(void);
   void GenProcessForCGI(const std::string &path_uri);
   void SetPipe(int *pipe_write, int *pipe_read);

--- a/srcs/HttpMessage.cpp
+++ b/srcs/HttpMessage.cpp
@@ -1,7 +1,5 @@
 #include "HttpMessage.hpp"
 
-#include "utility.hpp"
-
 HttpMessage::HttpMessage() : status_(STARTLINE), delim_("\r\n") {}
 
 HttpMessage::~HttpMessage() {}

--- a/srcs/HttpMessage.hpp
+++ b/srcs/HttpMessage.hpp
@@ -29,9 +29,6 @@ class HttpMessage {
   http_header headers_;
   std::string body_;
 
-  HttpMessage(const HttpMessage&);
-  HttpMessage& operator=(const HttpMessage&);
-
   virtual void ParseMessage();
   virtual void ParseStartline();
   virtual void ParseHeader();
@@ -71,11 +68,15 @@ class HttpMessage {
     ParseStartlineException(const std::string& what)
         : std::runtime_error(what) {}
   };
-
   class HeaderKeyException : public std::invalid_argument {
    public:
     HeaderKeyException(const std::string& what) : std::invalid_argument(what) {}
   };
+
+ private:
+  /* prohibit copy constructor and assignment operator */
+  HttpMessage(const HttpMessage&);
+  HttpMessage& operator=(const HttpMessage&);
 };
 
 #endif /* HTTPMESSAGE_HPP */

--- a/srcs/ISocket.hpp
+++ b/srcs/ISocket.hpp
@@ -1,5 +1,5 @@
-#ifndef SOCKET_HPP
-#define SOCKET_HPP
+#ifndef ISOCKET_HPP
+#define ISOCKET_HPP
 
 #include <netinet/in.h>
 
@@ -7,11 +7,11 @@
 
 #include "utility.hpp"
 
-class Socket {
+class ISocket {
  public:
-  Socket(){};
-  Socket(int port, std::string host_ip) : port_(port), host_ip_(host_ip){};
-  virtual ~Socket(){};
+  ISocket(){};
+  ISocket(int port, std::string host_ip) : port_(port), host_ip_(host_ip){};
+  virtual ~ISocket(){};
 
  protected:
   struct sockaddr_in addr_;
@@ -21,8 +21,8 @@ class Socket {
   enum SocketStatus socket_status_;
 
  private: /* prohibit */
-  Socket(const Socket&);
-  Socket& operator=(const Socket&);
+  ISocket(const ISocket&);
+  ISocket& operator=(const ISocket&);
 };
 
 #endif

--- a/srcs/ISocket.hpp
+++ b/srcs/ISocket.hpp
@@ -20,7 +20,8 @@ class ISocket {
 
   enum SocketStatus socket_status_;
 
- private: /* prohibit */
+ private:
+  /* prohibit copy constructor and assignment operator */
   ISocket(const ISocket&);
   ISocket& operator=(const ISocket&);
 };

--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -5,9 +5,6 @@
 
 class Request : public HttpMessage {
  private:
-  Request(const Request& other);
-  Request& operator=(const Request& rhs);
-
   enum Method method_;
   std::string uri_;
 
@@ -30,6 +27,10 @@ class Request : public HttpMessage {
   };
 
  private:
+  /* prohibit copy constructor and assignment operator */
+  Request(const Request& other);
+  Request& operator=(const Request& rhs);
+
   virtual void ParseMessage();
   virtual void ParseStartline();
   virtual void ParseHeader();

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,7 +1,5 @@
 #include "Response.hpp"
 
-#include <sstream>
-
 Response::Status::Status() {
   code[100] = "Continue";
   code[101] = "Swithing Protocol";
@@ -158,7 +156,8 @@ std::string Response::ErrorStatusLine(int status) {
   return (s.str());
 }
 
-void Response::AutoIndexResponse(const std::string& path, const std::string& index_of) {
+void Response::AutoIndexResponse(const std::string& path,
+                                 const std::string& index_of) {
   Clear();
   SetStatusCode(200);
   AppendHeader("Content-Type", "text/html");
@@ -185,7 +184,8 @@ void Response::RedirectResponse(int code, std::string location) {
   AppendHeader("Location", location);
 }
 
-std::string Response::AutoIndexHtml(const std::string& dir_path, const std::string& index_of) {
+std::string Response::AutoIndexHtml(const std::string& dir_path,
+                                    const std::string& index_of) {
   DIR* dirp = opendir(dir_path.c_str());
   if (dirp == NULL) return "";
   struct dirent* dp;

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -21,14 +21,6 @@ class Response : public HttpMessage {
   };
   static const Status kResponseStatus;
 
- private:
-  int status_code_;
-  std::string status_message_;
-
-  Response(const Response& other);
-  Response& operator=(const Response& rhs);
-
- public:
   Response();
   ~Response();
 
@@ -52,6 +44,13 @@ class Response : public HttpMessage {
   };
 
  private:
+  int status_code_;
+  std::string status_message_;
+
+  /* prohibit copy constructor and assignment operator */
+  Response(const Response& other);
+  Response& operator=(const Response& rhs);
+
   void SetStatusMessage(const std::string& reason);
   virtual void ParseMessage();
   virtual void ParseStartline();
@@ -61,7 +60,8 @@ class Response : public HttpMessage {
   std::string ErrorHtml(int status);
   std::string ErrorStatusLine(int status);
 
-  std::string AutoIndexHtml(const std::string& path, const std::string& index_of);
+  std::string AutoIndexHtml(const std::string& path,
+                            const std::string& index_of);
 };
 
 #endif /* RESPONSE_HPP */

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,8 +1,9 @@
 #include "Server.hpp"
 
-#include <netdb.h>
+Server::Server(const config::Config& config)
+    : ISocket(config.GetPort(), config.GetHost()), config_(config){};
 
-#include <stdexcept>
+Server::~Server(){};
 
 int Server::OpenListenSocket() {
   struct addrinfo hints, *listp, *p;
@@ -45,4 +46,4 @@ int Server::OpenListenSocket() {
   return listenfd;
 }
 
-const config::Config &Server::GetConfig() const { return config_; }
+const config::Config& Server::GetConfig() const { return config_; }

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -20,6 +20,9 @@ class Server : public Socket {
   const config::Config& GetConfig() const;
 
  private:
+  Server(const Server&);
+  Server& operator=(const Server&);
+
   config::Config config_;
 };
 

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -11,10 +11,10 @@
 #include "ISocket.hpp"
 #include "config.hpp"
 
-class Server : public Socket {
+class Server : public ISocket {
  public:
-  Server(const config::Config& config)
-      : Socket(config.GetPort(), config.GetHost()), config_(config){};
+  Server(const config::Config& config);
+  ~Server();
 
   int OpenListenSocket();
   const config::Config& GetConfig() const;

--- a/srcs/Server.hpp
+++ b/srcs/Server.hpp
@@ -20,6 +20,7 @@ class Server : public ISocket {
   const config::Config& GetConfig() const;
 
  private:
+  /* prohibit copy constructor and assignment operator */
   Server(const Server&);
   Server& operator=(const Server&);
 

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -27,22 +27,91 @@ WebServ::~WebServ() {
   sockets_.clear();
 }
 
-void WebServ::ParseConfig(const std::string &path) {
-  config::Parser parser(path);
+void WebServ::Activate(void) {
+  int hit = 0;
+  int n;
 
-  std::vector<config::Config> configs = parser.GetConfigs();
-  if (configs.empty()) return;
-
-  std::vector<config::Config>::const_iterator itr;
-  for (itr = configs.begin(); itr != configs.end(); ++itr) {
-    Server *server = new Server(*itr);
-    int fd = server->OpenListenSocket();
-    sockets_[fd] = server;
+  while (true) {
+    if ((n = HasUsableIO()) <= 0) throw std::runtime_error("select error\n");
+    for (std::map<int, Socket *>::iterator it = sockets_.begin();
+         n && it != sockets_.end(); ++it) {
+      try {
+        if (dynamic_cast<Server *>(it->second)) {
+          if (AcceptSession(it) == 0) --n;
+        } else {
+          if ((hit = ExecClientEvent(it)) > 0) n -= hit;
+        }
+      } catch (ft::HttpResponseException &e) {
+        Client *client = dynamic_cast<Client *>(it->second);
+        client->HandleException(e.what());
+      }
+    }
   }
 }
 
+int WebServ::HasUsableIO() {
+  int n = 0;
+
+  while (n == 0) {
+    FD_ZERO(&rfd_set_);
+    FD_ZERO(&wfd_set_);
+    max_fd_ = 0;
+
+    for (std::map<int, Socket *>::iterator it = sockets_.begin();
+         it != sockets_.end(); ++it) {
+      // set listening sockets_
+      if (dynamic_cast<Server *>(it->second)) {
+        int serevr_fd = it->first;
+
+        FD_SET(serevr_fd, &rfd_set_);
+        max_fd_ = std::max(max_fd_, serevr_fd);
+      } else {
+        int client_fd = it->first;
+        Client *client = dynamic_cast<Client *>(sockets_[client_fd]);
+
+        switch (client->GetStatus()) {
+          case READ_CLIENT:
+            FD_SET(client_fd, &rfd_set_);
+            max_fd_ = std::max(max_fd_, client_fd);
+            break;
+
+          case WRITE_CLIENT:
+            FD_SET(client_fd, &wfd_set_);
+            max_fd_ = std::max(max_fd_, client_fd);
+            break;
+
+          case READ_FILE:
+            FD_SET(client->GetReadFd(), &rfd_set_);
+            max_fd_ = std::max(max_fd_, client->GetReadFd());
+            break;
+
+          case WRITE_FILE:
+            FD_SET(client->GetWriteFd(), &wfd_set_);
+            max_fd_ = std::max(max_fd_, client->GetWriteFd());
+            break;
+
+          case READ_CGI:
+            FD_SET(client->GetReadFd(), &rfd_set_);
+            max_fd_ = std::max(max_fd_, client->GetReadFd());
+            break;
+
+          case READ_WRITE_CGI:
+            FD_SET(client->GetReadFd(), &rfd_set_);
+            FD_SET(client->GetWriteFd(), &wfd_set_);
+            max_fd_ = std::max(
+                max_fd_, std::max(client->GetWriteFd(), client->GetReadFd()));
+            break;
+        }
+      }
+    }
+
+    n = select(max_fd_ + 1, &rfd_set_, &wfd_set_, NULL, &timeout_);
+  }
+
+  return n;
+}
+
 int WebServ::AcceptSession(socket_iter it) {
-  int accepted = -1;
   int server_fd = it->first;
 
   if (FD_ISSET(server_fd, &rfd_set_)) {
@@ -54,9 +123,9 @@ int WebServ::AcceptSession(socket_iter it) {
     if (client_fd > max_fd_) max_fd_ = client_fd;
     sockets_[client_fd] = client;
 
-    accepted = 1;
+    return 0;
   }
-  return accepted;
+  return -1;
 }
 
 void WebServ::ReadClient(socket_iter it) {
@@ -122,68 +191,6 @@ void WebServ::WriteCGI(socket_iter it) {
   client->WriteCGIin();
 }
 
-int WebServ::HasUsableIO() {
-  int n = 0;
-
-  while (n == 0) {
-    FD_ZERO(&rfd_set_);
-    FD_ZERO(&wfd_set_);
-    max_fd_ = 0;
-
-    for (std::map<int, Socket *>::iterator it = sockets_.begin();
-         it != sockets_.end(); ++it) {
-      // set listening sockets_
-      if (dynamic_cast<Server *>(it->second)) {
-        int serevr_fd = it->first;
-
-        FD_SET(serevr_fd, &rfd_set_);
-        max_fd_ = std::max(max_fd_, serevr_fd);
-      } else {
-        int client_fd = it->first;
-        Client *client = dynamic_cast<Client *>(sockets_[client_fd]);
-
-        switch (client->GetStatus()) {
-          case READ_CLIENT:
-            FD_SET(client_fd, &rfd_set_);
-            max_fd_ = std::max(max_fd_, client_fd);
-            break;
-
-          case WRITE_CLIENT:
-            FD_SET(client_fd, &wfd_set_);
-            max_fd_ = std::max(max_fd_, client_fd);
-            break;
-
-          case READ_FILE:
-            FD_SET(client->GetReadFd(), &rfd_set_);
-            max_fd_ = std::max(max_fd_, client->GetReadFd());
-            break;
-
-          case WRITE_FILE:
-            FD_SET(client->GetWriteFd(), &wfd_set_);
-            max_fd_ = std::max(max_fd_, client->GetWriteFd());
-            break;
-
-          case READ_CGI:
-            FD_SET(client->GetReadFd(), &rfd_set_);
-            max_fd_ = std::max(max_fd_, client->GetReadFd());
-            break;
-
-          case READ_WRITE_CGI:
-            FD_SET(client->GetReadFd(), &rfd_set_);
-            FD_SET(client->GetWriteFd(), &wfd_set_);
-            max_fd_ = std::max(
-                max_fd_, std::max(client->GetWriteFd(), client->GetReadFd()));
-            break;
-        }
-      }
-    }
-
-    n = select(max_fd_ + 1, &rfd_set_, &wfd_set_, NULL, &timeout_);
-  }
-
-  return n;
-}
-
 int WebServ::ExecClientEvent(socket_iter it) {
   int hit = 0;
   int client_fd = it->first;
@@ -227,24 +234,16 @@ int WebServ::ExecClientEvent(socket_iter it) {
   return hit;
 }
 
-void WebServ::Activate(void) {
-  int hit = 0;
-  int n;
+void WebServ::ParseConfig(const std::string &path) {
+  config::Parser parser(path);
 
-  while (true) {
-    if ((n = HasUsableIO()) <= 0) throw std::runtime_error("select error\n");
-    for (std::map<int, Socket *>::iterator it = sockets_.begin();
-         n && it != sockets_.end(); ++it) {
-      try {
-        if (dynamic_cast<Server *>(it->second)) {
-          if (AcceptSession(it) == 1) --n;
-        } else {
-          if ((hit = ExecClientEvent(it)) > 0) n -= hit;
-        }
-      } catch (ft::HttpResponseException &e) {
-        Client *client = dynamic_cast<Client *>(it->second);
-        client->HandleException(e.what());
-      }
-    }
+  std::vector<config::Config> configs = parser.GetConfigs();
+  if (configs.empty()) return;
+
+  std::vector<config::Config>::const_iterator itr;
+  for (itr = configs.begin(); itr != configs.end(); ++itr) {
+    Server *server = new Server(*itr);
+    int fd = server->OpenListenSocket();
+    sockets_[fd] = server;
   }
 }

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -10,7 +10,7 @@
 #include "Server.hpp"
 #include "config.hpp"
 
-const std::string WebServ::default_path_ = "./conf/basic.conf";
+const std::string WebServ::default_path_ = "./conf/default.conf";
 
 WebServ::WebServ(const std::string &path) {
   timeout_ = (struct timeval){1, 0};

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -20,7 +20,7 @@ WebServ::WebServ(const std::string &path) {
 
 WebServ::~WebServ() {
   // delete all pointers
-  for (std::map<int, Socket *>::iterator it = sockets_.begin();
+  for (std::map<int, ISocket *>::iterator it = sockets_.begin();
        it != sockets_.end(); ++it) {
     delete it->second;
   }
@@ -33,7 +33,7 @@ void WebServ::Activate(void) {
 
   while (true) {
     if ((n = HasUsableIO()) <= 0) throw std::runtime_error("select error\n");
-    for (std::map<int, Socket *>::iterator it = sockets_.begin();
+    for (std::map<int, ISocket *>::iterator it = sockets_.begin();
          n && it != sockets_.end(); ++it) {
       try {
         if (dynamic_cast<Server *>(it->second)) {
@@ -57,7 +57,7 @@ int WebServ::HasUsableIO() {
     FD_ZERO(&wfd_set_);
     max_fd_ = 0;
 
-    for (std::map<int, Socket *>::iterator it = sockets_.begin();
+    for (std::map<int, ISocket *>::iterator it = sockets_.begin();
          it != sockets_.end(); ++it) {
       // set listening sockets_
       if (dynamic_cast<Server *>(it->second)) {

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -22,7 +22,8 @@ void WebServ::Activate(void) {
   int n;
 
   while (true) {
-    if ((n = HasUsableIO()) <= 0) throw std::runtime_error("select error\n");
+    if ((n = HasUsableIO()) <= 0)
+      throw std::runtime_error("select: " + std::string(strerror(errno)));
     for (std::map<int, ISocket *>::iterator it = sockets_.begin();
          n && it != sockets_.end(); ++it) {
       try {
@@ -127,7 +128,8 @@ void WebServ::ReadClient(socket_iter it) {
     close(client_fd);
     delete it->second;
     sockets_.erase(it);
-    if (ret < 0) throw std::runtime_error(strerror(errno));
+    if (ret < 0)
+      throw std::runtime_error("recv: " + std::string(strerror(errno)));
   }
 }
 
@@ -140,7 +142,7 @@ void WebServ::ReadFile(socket_iter it) {
     close(client_fd);
     delete it->second;
     sockets_.erase(it);
-    throw std::runtime_error(strerror(errno));
+    throw std::runtime_error("read: " + std::string(strerror(errno)));
   }
 }
 
@@ -153,7 +155,7 @@ void WebServ::ReadCGI(socket_iter it) {
     close(client_fd);
     delete it->second;
     sockets_.erase(it);
-    throw std::runtime_error(strerror(errno));
+    throw std::runtime_error("read: " + std::string(strerror(errno)));
   }
 }
 
@@ -165,7 +167,7 @@ void WebServ::WriteClient(socket_iter it) {
   if ((ret = client->SendResponse(client_fd)) < 0) {
     close(client_fd);
     sockets_.erase(it);
-    throw std::runtime_error(strerror(errno));
+    throw std::runtime_error("send: " + std::string(strerror(errno)));
   }
 }
 

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -49,7 +49,7 @@ int WebServ::AcceptSession(socket_iter it) {
     Server *server = dynamic_cast<Server *>(it->second);
     Client *client = new Client(server->GetConfig());
 
-    int client_fd = client->SetSocket(server_fd);
+    int client_fd = client->ConnectClientSocket(server_fd);
 
     if (client_fd > max_fd_) max_fd_ = client_fd;
     sockets_[client_fd] = client;

--- a/srcs/WebServ.cpp
+++ b/srcs/WebServ.cpp
@@ -1,15 +1,5 @@
 #include "WebServ.hpp"
 
-#include <unistd.h>
-
-#include <cstring>
-#include <iostream>
-#include <stdexcept>
-
-#include "Client.hpp"
-#include "Server.hpp"
-#include "config.hpp"
-
 const std::string WebServ::default_path_ = "./conf/default.conf";
 
 WebServ::WebServ(const std::string &path) {

--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -1,12 +1,10 @@
 #ifndef WEBSERV_HPP
 #define WEBSERV_HPP
 
-#include <map>
-#include <string>
-
+#include "Client.hpp"
 #include "ISocket.hpp"
-
-class Client;
+#include "Server.hpp"
+#include "config.hpp"
 
 class WebServ {
  public:

--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -10,12 +10,8 @@ class Client;
 
 class WebServ {
  public:
-  WebServ(const WebServ&);
-  WebServ& operator=(const WebServ&);
-
   typedef std::map<int, ISocket*>::iterator socket_iter;
 
- public:
   WebServ(const std::string& path);
   ~WebServ();
 
@@ -24,6 +20,10 @@ class WebServ {
   static const std::string default_path_;
 
  private:
+  /* prohibit copy constructor and assignment operator */
+  WebServ(const WebServ&);
+  WebServ& operator=(const WebServ&);
+
   int HasUsableIO();
 
   int AcceptSession(socket_iter it);

--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -13,7 +13,7 @@ class WebServ {
   WebServ(const WebServ&);
   WebServ& operator=(const WebServ&);
 
-  typedef std::map<int, Socket*>::iterator socket_iter;
+  typedef std::map<int, ISocket*>::iterator socket_iter;
 
  public:
   WebServ(const std::string& path);
@@ -43,7 +43,7 @@ class WebServ {
   fd_set rfd_set_, wfd_set_;
   struct timeval timeout_;
 
-  std::map<int, Socket*> sockets_;
+  std::map<int, ISocket*> sockets_;
 
   std::map<int, std::string> cgi_outputs_;
 };

--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -10,6 +10,9 @@ class Client;
 
 class WebServ {
  public:
+  WebServ(const WebServ&);
+  WebServ& operator=(const WebServ&);
+
   typedef std::map<int, Socket*>::iterator socket_iter;
 
  public:

--- a/srcs/config.cpp
+++ b/srcs/config.cpp
@@ -217,7 +217,7 @@ std::vector<Config> Parser::GetConfigs() {
 void Parser::Load() {
   std::ifstream file(filename_);
   if (!file.is_open()) {
-    throw std::runtime_error("file could not be opened");
+    throw std::runtime_error("config: file could not be opened");
   }
 
   Directives mapping;

--- a/srcs/config.cpp
+++ b/srcs/config.cpp
@@ -1,9 +1,5 @@
 #include "config.hpp"
 
-#include <algorithm>
-
-#include "Client.hpp"
-
 namespace {
 
 std::string::const_iterator skip_leading_whitespace(

--- a/srcs/config.hpp
+++ b/srcs/config.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cctype>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <list>
 #include <map>
@@ -12,7 +13,6 @@
 #include <sstream>
 #include <string>
 #include <vector>
-#include <iomanip>
 
 #include "utility.hpp"
 
@@ -102,11 +102,8 @@ struct LineComponent;
 
 class Parser {
  private:
-  typedef void (Parser::*AddDirective)(
-    enum Context,
-    const std::string& name,
-    const std::vector<std::string>& params
-  );
+  typedef void (Parser::*AddDirective)(enum Context, const std::string& name,
+                                       const std::vector<std::string>& params);
 
   typedef std::map<std::string, AddDirective> Directives;
 
@@ -118,6 +115,9 @@ class Parser {
   void Print() const;
 
  private:
+  Parser(const Parser& other);
+  Parser& operator=(const Parser& other);
+
   bool print_config_;
   std::string filename_;
   struct Main main_;
@@ -192,12 +192,12 @@ class Parser {
   class ContextError : public std::runtime_error {
    public:
     ContextError() : std::runtime_error("config: context error") {}
-    ContextError(const std::string& what) : std::runtime_error(what) {};
+    ContextError(const std::string& what) : std::runtime_error(what){};
   };
   class ParameterError : public std::runtime_error {
    public:
     ParameterError() : std::runtime_error("config: parameter error") {}
-    ParameterError(const std::string& what) : std::runtime_error(what) {};
+    ParameterError(const std::string& what) : std::runtime_error(what){};
   };
 };
 
@@ -222,6 +222,9 @@ class LineBuilder {
   bool GetNext(LineComponent& line);
 
  private:
+  LineBuilder(const LineBuilder& other);
+  LineBuilder& operator=(const LineBuilder& other);
+
   std::ifstream& file_;
   std::string current_;
 

--- a/srcs/config.hpp
+++ b/srcs/config.hpp
@@ -115,6 +115,7 @@ class Parser {
   void Print() const;
 
  private:
+  /* prohibit copy constructor and assignment operator */
   Parser(const Parser& other);
   Parser& operator=(const Parser& other);
 
@@ -222,6 +223,7 @@ class LineBuilder {
   bool GetNext(LineComponent& line);
 
  private:
+  /* prohibit copy constructor and assignment operator */
   LineBuilder(const LineBuilder& other);
   LineBuilder& operator=(const LineBuilder& other);
 

--- a/srcs/utility.cpp
+++ b/srcs/utility.cpp
@@ -1,14 +1,4 @@
-#include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/time.h>
-
-#include <ctime>
-#include <sstream>
-#include <vector>
-
-namespace ft {
+#include "utility.hpp"
 
 namespace {
 
@@ -28,6 +18,8 @@ int count(std::string s, char c) {
 }
 
 }  // namespace
+
+namespace ft {
 
 char **split(std::string s, char c) {
   char **p;

--- a/srcs/utility.hpp
+++ b/srcs/utility.hpp
@@ -2,9 +2,11 @@
 #define UTILITY_HPP
 
 #include <netinet/in.h>
+#include <sys/time.h>
 
 #include <cstdlib>
 #include <ctime>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/test/ClientTest.cpp
+++ b/test/ClientTest.cpp
@@ -14,10 +14,10 @@ class ClientTest : public testing::Test {
 };
 
 TEST_F(ClientTest, IsValidExtension) {
-  config::Parser parser("../../conf/basic.conf");
+  config::Parser parser("../../conf/default.conf");
   std::vector<config::Config> configs = parser.GetConfigs();
 
-  Server server(configs[0]);  // basic.conf's first server(listening 4200)
+  Server server(configs[0]);  // default.conf's first server(listening 4200)
   Client client(server.GetConfig());
 
   EXPECT_TRUE(client.IsValidExtension("./docs/abc.py", "/abc.py"));
@@ -36,7 +36,7 @@ TEST_F(ClientTest, IsValidExtension) {
 }
 
 TEST_F(ClientTest, GetIndexFileIfExist) {
-  config::Parser parser("../../conf/basic.conf");
+  config::Parser parser("../../conf/default.conf");
   std::vector<config::Config> configs = parser.GetConfigs();
 
   Server server(configs[0]);
@@ -51,10 +51,10 @@ TEST_F(ClientTest, GetIndexFileIfExist) {
 }
 
 TEST_F(ClientTest, IsValidUploadRequest) {
-  config::Parser parser("../../conf/basic.conf");
+  config::Parser parser("../../conf/default.conf");
   std::vector<config::Config> configs = parser.GetConfigs();
 
-  Server server(configs[1]);  // basic.conf's second server(listening 4201)
+  Server server(configs[1]);  // default.conf's second server(listening 4201)
   Client client(server.GetConfig());
 
   chdir("../../");
@@ -73,21 +73,17 @@ TEST_F(ClientTest, IsValidUploadRequest) {
 }
 
 TEST_F(ClientTest, MakePathUri) {
-  config::Parser parser("../../conf/basic.conf");
+  config::Parser parser("../../conf/default.conf");
   std::vector<config::Config> configs = parser.GetConfigs();
 
-  Server server(configs[1]);  // basic.conf's second server(listening 4201)
+  Server server(configs[1]);  // default.conf's second server(listening 4201)
   Client client(server.GetConfig());
 
   // std::string MakePathUri(std::string alias_path, std::string request_uri,
   // std::string location_path);
   // alias_path + (request_uri - location_path)
-  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"),
-            "./docs/top.gif");
-  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"),
-            "./docs/top.gif");
-  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/"),
-            "./docs/i/top.gif");
-  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"),
-            "./docs/top.gif");
+  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"), "./docs/top.gif");
+  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"), "./docs/top.gif");
+  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/"), "./docs/i/top.gif");
+  EXPECT_EQ(client.MakePathUri("/i/top.gif", "/i/"), "./docs/top.gif");
 }

--- a/test/http/httptest
+++ b/test/http/httptest
@@ -9,29 +9,29 @@ import os
 server = Server()
 
 ##############################
-server.run("basic.conf")######
+server.run("default.conf")######
 ##############################
 
-case = Case("nonexist folder", "GET", "http://localhost:8008/abc")
+case = Case("nonexist folder", "GET", "http://localhost:80/abc")
 case.status_code(404)
 case.body_has("404 Not Found")
 case.header_has("Content-Length")
 
 
-case = Case("index file", "GET", "http://localhost:8008?key1=val1&key2=val2")
+case = Case("index file", "GET", "http://localhost:80?key1=val1&key2=val2")
 case.status_code(200)
 case.body_has("html")
 case.header_has("Content-Length")
 
 
 payload = {"key1": "val1", "key2": "val2"} # リクエストヘッダ
-case = Case("extra request header", "GET", "http://localhost:8008", headers=payload)
+case = Case("extra request header", "GET", "http://localhost:80", headers=payload)
 case.status_code(200)
 case.body_has("めざせいっかげつ")
 case.header_has("Content-Length")
 
 
-case = Case("post 405", "POST", "http://localhost:8008", body="this is body.")
+case = Case("post 405", "POST", "http://localhost:80", body="this is body.")
 case.status_code(405)
 case.body_is(".*html.*")
 case.header_has("Content-Length")
@@ -64,13 +64,13 @@ case.body_has("Index of")
 case.header_has("Content-Length")
 
 
-case = Case("redirect 301", "GET", "http://localhost:8008/kapouet/")
+case = Case("redirect 301", "GET", "http://localhost:80/kapouet/")
 case.status_code(301)
 case.header_has("Content-Length")
 case.header_has("Location")
 
 
-case = Case("cgi", "POST", "http://localhost:8008/cgi/perl.py", body="key1=val1&key2=val2")
+case = Case("cgi", "POST", "http://localhost:80/cgi/perl.py", body="key1=val1&key2=val2")
 case.status_code(200)
 case.header_has("Content-Length")
 case.body_is("<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<title>CGI TEST</title>\n</head>\n<body>\n<h1>CGI TEST</h1>\n<pre>\n.*")
@@ -78,7 +78,7 @@ case.body_is("<!doctype html>\n<html>\n<head>\n<meta charset=\"utf-8\">\n<title>
 
 subprocess.run(("touch", "./docs/html/cant_read"))
 os.chmod("./docs/html/cant_read", 660)
-case = Case("forbidden file acces", "GET", "http://localhost:8008/cant_read")
+case = Case("forbidden file acces", "GET", "http://localhost:80/cant_read")
 case.status_code(403)
 case.header_has("Content-Length")
 case.body_has("403")

--- a/test/http/run.py
+++ b/test/http/run.py
@@ -16,9 +16,8 @@ class Server():
 		else:
 			print("\n" + Color.BOLD + Color.REVERCE + "./webserv" + Color.END + Color.END)
 			subprocess.Popen(('./webserv'), stdout=subprocess.DEVNULL)
-			config_name = "basic.conf"
+			config_name = "default.conf"
 		time.sleep(2)
 
 	def stop(self):
 		subprocess.run(('pkill', 'webserv'))
-


### PR DESCRIPTION
## ヘッダーのプロトタイプ宣言の順番とソースコードの定義の順番
コードの上部にpublicなものが来るのと、メソッドを探しやすくするのが目的です。

## コピーコンストラクタと代入演算子のオーバーロードの追加
デフォルトでpublicに定義されてしまうのを防ぐため、privateに宣言だけ追加しました。
基本的には使用しないはずです。

## ヘッダーのインクルードをヘッダーでのみ行う
cppファイルは同名のヘッダーのみのインクルードとしました。
他に必要なヘッダーはヘッダーファイル内でインクルードしました。

## クラス名と関数名の変更
Clientクラス内のSetSocketをConnectClientSocketに変更しました。
処理に即した名前になった？かな？と思います。

SocketクラスをISocketクラスに変更しました。
インターフェースクラスであることが明白になるように`I`をつけました。
ファイル名に合うように変更しました。

## デフォルトのconfig file を default.confに変更
以前の`basic.conf`と`default.conf`の名前を入れ替えました。
httptestなどの中身も入れ替えています。

## 例外時の内容修正
システムコールのエラー時のメッセージをerrnoを利用したものに修正しました。

## リクエスト・レスポンスのログの修正
webserv実行中の標準出力に対するログ出力のフォーマットを修正しました。
nginxっぽいログにしました。

## その他
Clientはもうちょっと綺麗にしたいです。