### PR TITLE
feat(server): ignore multiple server directives with same host:port

### DIFF
--- a/srcs/WebServ.hpp
+++ b/srcs/WebServ.hpp
@@ -36,6 +36,7 @@ class WebServ {
   int ExecClientEvent(socket_iter it);
 
   void ParseConfig(const std::string& path);
+  bool IsHostPortUsed(const std::string& host, int port);
 
   int max_fd_;
   fd_set rfd_set_, wfd_set_;

--- a/test/conf/same_server.conf
+++ b/test/conf/same_server.conf
@@ -1,0 +1,4 @@
+server{listen 4200;}
+server{listen 4200;}
+server{listen 4200;}
+server{}server{}server{}


### PR DESCRIPTION
#80

### 変更点
`Webserv::ParseConfig` でサーバーソケットを立ち上げる際、すでに同一host:portを持ったServerがないか確認します。

### 挙動
以下のnginxの挙動を参考にしています。複数の同一host:portを持ったServerディレクティブが存在した場合、最初のServerをデフォルトとし、それ以降のServerを立ち上げ時に無視します。
```
server {
    listen 8000;
}

server {
    listen 8000;
}

server {
    listen 8000;
}

server {
  listen 127.0.0.1:80;
}

server {
  listen 127.0.0.1:80;
}

```

```
nginx: [warn] conflicting server name "" on 0.0.0.0:8000, ignored
nginx: [warn] conflicting server name "" on 0.0.0.0:8000, ignored
nginx: [warn] conflicting server name "" on 127.0.0.1:80, ignored
```