### PR TITLE
make it possible to upload files at /

### DIFF
--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -35,6 +35,8 @@ int Client::RecvRequest(int client_fd) {
   try {
     request_.AppendRawData(buf, ret);
     if (request_.GetStatus() == HttpMessage::DONE) {
+      // this is the first time to call of config getter
+      // so this might throw 404 and that's OK!
       size_t max_body_size = config_.GetClientMaxBodySize(request_.GetURI());
 
       if (max_body_size != 0 && max_body_size < request_.GetBody().size()) {

--- a/srcs/config.cpp
+++ b/srcs/config.cpp
@@ -229,6 +229,10 @@ std::pair<int, std::string> Config::GetRedirect(const std::string& uri) const {
 
 bool Config::HasLocation() const { return !server_.locations.empty(); }
 
+std::map<int, std::string> Config::GetMainAndServerErrorPages() const {
+  return server_.error_pages;
+}
+
 Parser::Parser(const std::string& filename) : filename_(filename) { Load(); }
 
 Parser::~Parser() {}

--- a/srcs/config.hpp
+++ b/srcs/config.hpp
@@ -92,6 +92,7 @@ class Config {
   std::set<enum Method> GetAllowedMethods(const std::string& uri) const;
   std::pair<int, std::string> GetRedirect(const std::string& uri) const;
   bool HasLocation() const;
+  std::map<int, std::string> GetMainAndServerErrorPages() const;
 
  private:
   struct Server server_;


### PR DESCRIPTION
404が出て終了する原因はHandleExceptionでconfig_.GetErrorPagesを呼び出して404が投げられるからでした。

なのでHandleExceptionでもconfig_.GetErrorPagesをtryでみて、もし例外が投げられるようならerror_pagesをMainコンテキストとServerコンテキストからとってくるようにしました。

上記を修正すれば/にuploadするものも
```cpp
store = store.empty() ? "/" : store;
```
でできました。